### PR TITLE
空操作数不能执行小于等于操作符

### DIFF
--- a/src/main/java/com/ql/util/express/instruction/op/OperatorEqualsLessMore.java
+++ b/src/main/java/com/ql/util/express/instruction/op/OperatorEqualsLessMore.java
@@ -42,6 +42,8 @@ public class OperatorEqualsLessMore extends Operator {
 				return false;
 			} else if (opStr.equals("!=") || opStr.equals("<>")) {
 				return true;
+			} else if (opStr.equals("<=") ) {
+				return false;
 			} else {
 				throw new Exception("空操作数不能执行这个操作：" + opStr);
 			}

--- a/src/main/java/com/ql/util/express/instruction/op/OperatorEqualsLessMore.java
+++ b/src/main/java/com/ql/util/express/instruction/op/OperatorEqualsLessMore.java
@@ -42,7 +42,7 @@ public class OperatorEqualsLessMore extends Operator {
 				return false;
 			} else if (opStr.equals("!=") || opStr.equals("<>")) {
 				return true;
-			} else if (opStr.equals("<=") ) {
+			} else if (opStr.equals("<=") || opStr.equals(">=") || opStr.equals("<")  || opStr.equals(">")  ) {
 				return false;
 			} else {
 				throw new Exception("空操作数不能执行这个操作：" + opStr);

--- a/src/test/java/com/ql/util/express/issues/Issue82ExpressNested.java
+++ b/src/test/java/com/ql/util/express/issues/Issue82ExpressNested.java
@@ -1,0 +1,44 @@
+package com.ql.util.express.issues;
+
+
+import com.ql.util.express.DefaultContext;
+import com.ql.util.express.ExpressRunner;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+public class Issue82ExpressNested {
+
+    @Test
+    public void expressNest() throws Exception {
+        String express = "order.orderType in (0,112,21) && skuPropertySatisfied(skuList, \"sku.categoryId == 3 && sku.price == 100\")";
+
+        ExpressRunner runner = new ExpressRunner();
+
+        Order order = new Order();
+        order.setOrderType(21);
+        order.setSkuList(makeSkuList());
+
+
+        DefaultContext<String, Object> context = new DefaultContext<String, Object>();
+        context.put("order", order);
+        context.put("skuList", order.getSkuList());
+
+        runner.addFunctionOfClassMethod("skuPropertySatisfied", SkuFunctionExpress.class.getName(),
+                "skuPropertySatisfied", new String[]{List.class.getName(), "String"}, null);
+
+
+        boolean orderSatisfied = (Boolean) runner.execute(express, context, null, true, false, null);
+
+        assertTrue(orderSatisfied);
+    }
+
+    private List<Sku> makeSkuList() {
+        return Collections.singletonList(new Sku(3, 100));
+    }
+
+}

--- a/src/test/java/com/ql/util/express/issues/Order.java
+++ b/src/test/java/com/ql/util/express/issues/Order.java
@@ -1,0 +1,24 @@
+package com.ql.util.express.issues;
+
+import java.util.List;
+
+public class Order {
+    int orderType;
+    List<Sku> skuList;
+
+    public int getOrderType() {
+        return orderType;
+    }
+
+    public void setOrderType(int orderType) {
+        this.orderType = orderType;
+    }
+
+    public List<Sku> getSkuList() {
+        return skuList;
+    }
+
+    public void setSkuList(List<Sku> skuList) {
+        this.skuList = skuList;
+    }
+}

--- a/src/test/java/com/ql/util/express/issues/Sku.java
+++ b/src/test/java/com/ql/util/express/issues/Sku.java
@@ -1,0 +1,27 @@
+package com.ql.util.express.issues;
+
+public class Sku {
+    int categoryId;
+    int price;
+
+    public Sku(int categoryId, int price) {
+        this.categoryId = categoryId;
+        this.price = price;
+    }
+
+    public int getCategoryId() {
+        return categoryId;
+    }
+
+    public void setCategoryId(int categoryId) {
+        this.categoryId = categoryId;
+    }
+
+    public int getPrice() {
+        return price;
+    }
+
+    public void setPrice(int price) {
+        this.price = price;
+    }
+}

--- a/src/test/java/com/ql/util/express/issues/Sku.java
+++ b/src/test/java/com/ql/util/express/issues/Sku.java
@@ -1,8 +1,12 @@
 package com.ql.util.express.issues;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class Sku {
     int categoryId;
     int price;
+    Map<String,Object> extProperties = new HashMap();
 
     public Sku(int categoryId, int price) {
         this.categoryId = categoryId;
@@ -23,5 +27,13 @@ public class Sku {
 
     public void setPrice(int price) {
         this.price = price;
+    }
+
+    public Map<String, Object> getExtProperties() {
+        return extProperties;
+    }
+
+    public void setExtProperties(Map<String, Object> extProperties) {
+        this.extProperties = extProperties;
     }
 }

--- a/src/test/java/com/ql/util/express/issues/SkuFunctionExpress.java
+++ b/src/test/java/com/ql/util/express/issues/SkuFunctionExpress.java
@@ -1,0 +1,31 @@
+package com.ql.util.express.issues;
+
+import com.ql.util.express.DefaultContext;
+import com.ql.util.express.ExpressRunner;
+
+import java.util.List;
+
+public class SkuFunctionExpress {
+    public boolean skuPropertySatisfied(List<Sku> skuList, String exressNested) {
+        ExpressRunner runner = new ExpressRunner();
+
+        for (Sku sku: skuList) {
+            DefaultContext<String, Object> context = new DefaultContext<String, Object>();
+            context.put("sku", sku);
+
+            try {
+                boolean expressNestedResult = (Boolean) runner.execute(exressNested, context, null,
+                        true, false, null);
+
+                if (expressNestedResult) {
+                    return true;
+                }
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+
+        }
+
+        return false;
+    }
+}

--- a/src/test/java/com/ql/util/express/issues/issue83/IssueNullOperator.java
+++ b/src/test/java/com/ql/util/express/issues/issue83/IssueNullOperator.java
@@ -1,0 +1,39 @@
+package com.ql.util.express.issues.issue83;
+
+
+import com.ql.util.express.DefaultContext;
+import com.ql.util.express.ExpressRunner;
+import com.ql.util.express.issues.Sku;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class IssueNullOperator {
+    ExpressRunner runner;
+    DefaultContext<String, Object> context;
+
+    @Before
+    public void setUp() {
+        runner = new ExpressRunner();
+        context = new DefaultContext();
+        context.put("sku", new Sku(3, 100));
+    }
+
+
+    @Test(expected = Test.None.class)
+    public void assert_null_operator_failed_when_less_than_compare() throws Exception {
+        String express = "sku.price == 100 && sku.extProperties.notExistKey <= 100";
+
+        assertFalse((Boolean) runner.execute(express, context, null, true, false, null));
+
+    }
+
+    @Test(expected = Test.None.class)
+    public void assert_null_operator_ok_when_compare_with_string() throws Exception {
+        String express = "sku.price == 100 && sku.extProperties.notExistKey == '5'";
+
+        runner.execute(express, context, null, true, false, null);
+    }
+
+}


### PR DESCRIPTION
Fixes #83

对于比较的符号， 看样子应该做成跟“==”一样的操作支持。 

