### PR TITLE
修复反斜杠\识别的bug

### DIFF
--- a/src/main/java/com/ql/util/express/parse/WordSplit.java
+++ b/src/main/java/com/ql/util/express/parse/WordSplit.java
@@ -36,7 +36,7 @@ public class WordSplit
 	       if (c=='"' || c=='\''){//字符串处理        
 	     	int index = str.indexOf(c,i + 1);
 	     	//处理字符串中的”问题
-	         while(index >0 && str.charAt(index - 1) =='\\'){
+	         while(index >0 && str.charAt(index - 1) =='\\' && str.charAt(index - 2) !='\\'){
 	         	index = str.indexOf(c,index + 1);
 	         }
 	         if (index < 0)

--- a/src/test/java/com/ql/util/express/bugfix/BackSlashTest.java
+++ b/src/test/java/com/ql/util/express/bugfix/BackSlashTest.java
@@ -1,0 +1,19 @@
+package com.ql.util.express.bugfix;
+
+import com.ql.util.express.DefaultContext;
+import com.ql.util.express.ExpressRunner;
+import com.ql.util.express.IExpressContext;
+import org.junit.Test;
+
+//脚本中包含 反斜杠 测试
+public class BackSlashTest {
+
+    @Test
+    public void test() throws Exception {
+        ExpressRunner runner = new ExpressRunner();
+        String exp = "a=\"\\\\\";";
+        IExpressContext<String, Object> context = new DefaultContext<String, Object>();
+        Object result = runner.execute(exp,context,null,false,true);
+        System.out.println(result);
+    }
+}


### PR DESCRIPTION
`当ql脚本内容中种有反斜杠\时，无法编译，如下面的脚本，应该 返回 \
`a=“\\”; return a;`
