### PR TITLE
修复数组类型推断的bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>2.1</version>
+				<version>2.1.1</version>
 				<configuration>
 					<attach>true</attach>
 				</configuration>
@@ -136,6 +136,11 @@
 					</execution>
 				</executions>
 			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.0</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>

--- a/src/main/java/com/ql/util/express/instruction/opdata/OperateDataArrayItem.java
+++ b/src/main/java/com/ql/util/express/instruction/opdata/OperateDataArrayItem.java
@@ -27,7 +27,7 @@ public class OperateDataArrayItem extends OperateDataAttr {
 		builder.append(this.index);
     }
 	public Class<?> getType(InstructionSetContext context) throws Exception {
-		  return this.arrayObject.getObject(context).getClass();
+		  return this.arrayObject.getObject(context).getClass().getComponentType();
 	}
 	public Object getObjectInner(InstructionSetContext context){
 		try {

--- a/src/test/java/com/ql/util/express/bugfix/ArrayItemTest.java
+++ b/src/test/java/com/ql/util/express/bugfix/ArrayItemTest.java
@@ -1,0 +1,31 @@
+package com.ql.util.express.bugfix;
+
+import com.ql.util.express.*;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ArrayItemTest {
+
+    @Test
+    public void issue37() throws Exception {
+        ExpressRunner runner = new ExpressRunner(false, true);
+
+        DefaultContext<String, Object> context = new DefaultContext<String, Object>();
+        String express = "part = \"1@2@3\".split(\"@\");\n" +
+                "Integer.valueOf(part[2]);";
+        Object res = runner.execute(express, context, null, true, true);
+        assertEquals(3, res);
+    }
+
+    @Test
+    public void issue43() throws Exception {
+        ExpressRunner runner = new ExpressRunner(false, true);
+        String exp = "System.out.println(args[0]);";
+        String[] args = {"123","456"};
+        DefaultContext<String, Object> context = new DefaultContext<String, Object>();
+        context.put("args", args);
+        runner.execute(exp,context,null,false,true);
+    }
+
+}


### PR DESCRIPTION
issue #43 #37 

bug 来源与 `OperateDataArrayItem.getType` 的实现有问题，应该获得数组中的元素类型，而不是返回数组本身的类型：

原先

```java
	public Class<?> getType(InstructionSetContext context) throws Exception {
		  return this.arrayObject.getObject(context).getClass();
	}
```

修改成

```java
	public Class<?> getType(InstructionSetContext context) throws Exception {
		  return this.arrayObject.getObject(context).getClass().getComponentType();
	}
```

即可解决问题