### PR TITLE
修复引擎无法在同一线程中嵌套执行的问题

### DIFF
--- a/src/main/java/com/ql/util/express/ExpressRunner.java
+++ b/src/main/java/com/ql/util/express/ExpressRunner.java
@@ -614,6 +614,23 @@ public class ExpressRunner {
 			 	isTrace,false,aLog,false);
 	}
 
+	/**
+	 * 用于同一线程中在引擎内部嵌套调用引擎, 比如实现类似 js 的 eval 函数 eval('1+1')
+	 * @param expressString
+	 * @param aContext
+	 * @param errorList
+	 * @param isTrace
+	 * @return
+	 * @throws Exception
+	 */
+	public Object eval(String expressString, IExpressContext<String,Object> aContext,
+					   List<String> errorList, boolean isTrace) throws Exception {
+		InstructionSet parseResult = this.parseInstructionSet(expressString);
+
+		return InstructionSetRunner.execute(this, parseResult, this.loader, aContext, errorList, isTrace,
+				false, true, null, false);
+	}
+
 	public RuleResult executeRule(String expressString, IExpressContext<String,Object> context, boolean isCache, boolean isTrace)
 			throws Exception {
 		Rule rule = null;

--- a/src/test/java/com/ql/util/express/bugfix/EvalTest.java
+++ b/src/test/java/com/ql/util/express/bugfix/EvalTest.java
@@ -1,0 +1,51 @@
+package com.ql.util.express.bugfix;
+
+import com.ql.util.express.*;
+import com.ql.util.express.instruction.op.OperatorBase;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * 测试引擎嵌套执行
+ */
+public class EvalTest {
+
+    @Test
+    public void evalTest() throws Exception {
+        String evalExpress = "eval('eval(\\'1+1\\')')";
+        final ExpressRunner runner = new ExpressRunner(false,true);
+        runner.addFunction("eval", new OperatorBase() {
+            @Override
+            public OperateData executeInner(InstructionSetContext parent, ArraySwap list) throws Exception {
+                Object res = runner.eval(list.get(0).toString(), parent,
+                        null, true);
+                return new OperateData(res, res.getClass());
+            }
+        });
+
+        Object res = runner.execute(evalExpress, new DefaultContext<String, Object>(), null,
+                false, true);
+        assertEquals(2, res);
+    }
+
+    @Test
+    public void evalUserVariableTest() throws Exception {
+        String evalExpress = "m = 'aaaa';" +
+                "eval('m')";
+        final ExpressRunner runner = new ExpressRunner(false,true);
+        runner.addFunction("eval", new OperatorBase() {
+            @Override
+            public OperateData executeInner(InstructionSetContext parent, ArraySwap list) throws Exception {
+                Object res = runner.eval(list.get(0).toString(), parent,
+                        null, true);
+                return new OperateData(res, res.getClass());
+            }
+        });
+
+        Object res = runner.execute(evalExpress, new DefaultContext<String, Object>(), null,
+                false, true);
+        assertEquals("aaaa", res);
+    }
+
+}

--- a/src/test/java/com/ql/util/express/test/ForFlowFunctionTest.java
+++ b/src/test/java/com/ql/util/express/test/ForFlowFunctionTest.java
@@ -1,10 +1,9 @@
 package com.ql.util.express.test;
 
+import com.ql.util.express.*;
+import com.ql.util.express.instruction.op.OperatorBase;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.ql.util.express.DefaultContext;
-import com.ql.util.express.ExpressRunner;
 
 
 public class ForFlowFunctionTest {
@@ -20,5 +19,4 @@ public class ForFlowFunctionTest {
 		Object r = runner.execute(express, context, null, false, true);
 		Assert.assertTrue("for循环后面跟着一个函数的时候错误", r.toString().equals("10"));
 	}
-
 }


### PR DESCRIPTION
修复 #122

单独在 ExpressRunner 中提供了一个 eval 函数来进行引擎嵌套执行，使用如下：

```java
    @Test
    public void evalTest() throws Exception {
        String evalExpress = "eval('eval(\\'1+1\\')')";
        final ExpressRunner runner = new ExpressRunner(false,true);
        runner.addFunction("eval", new OperatorBase() {
            @Override
            public OperateData executeInner(InstructionSetContext parent, ArraySwap list) throws Exception {
                Object res = runner.eval(list.get(0).toString(), parent,
                        null, true);
                return new OperateData(res, res.getClass());
            }
        });

        Object res = runner.execute(evalExpress, new DefaultContext<String, Object>(), null,
                false, true);
        assertEquals(2, res);
    }
```

其原理大约和“宏”差不多，直接调用了一个内部的 execute 方法，而不是 executeOuter，这样在脚本运行结束时就不会重置虚拟机指针导致问题了：

```java
	public Object eval(String expressString, IExpressContext<String,Object> aContext,
					   List<String> errorList, boolean isTrace) throws Exception {
		InstructionSet parseResult = this.parseInstructionSet(expressString);

		return InstructionSetRunner.execute(this, parseResult, this.loader, aContext, errorList, isTrace,
				false, true, null, false);
	}
```