### PR TITLE
修复 break continue 导致死循环的问题

### DIFF
--- a/src/main/java/com/ql/util/express/ExpressRunner.java
+++ b/src/main/java/com/ql/util/express/ExpressRunner.java
@@ -614,6 +614,23 @@ public class ExpressRunner {
 			 	isTrace,false,aLog,false);
 	}
 
+	/**
+	 * 用于同一线程中在引擎内部嵌套调用引擎, 比如实现类似 js 的 eval 函数 eval('1+1')
+	 * @param expressString
+	 * @param aContext
+	 * @param errorList
+	 * @param isTrace
+	 * @return
+	 * @throws Exception
+	 */
+	public Object eval(String expressString, IExpressContext<String,Object> aContext,
+					   List<String> errorList, boolean isTrace) throws Exception {
+		InstructionSet parseResult = this.parseInstructionSet(expressString);
+
+		return InstructionSetRunner.execute(this, parseResult, this.loader, aContext, errorList, isTrace,
+				false, true, null, false);
+	}
+
 	public RuleResult executeRule(String expressString, IExpressContext<String,Object> context, boolean isCache, boolean isTrace)
 			throws Exception {
 		Rule rule = null;

--- a/src/main/java/com/ql/util/express/instruction/ForInstructionFactory.java
+++ b/src/main/java/com/ql/util/express/instruction/ForInstructionFactory.java
@@ -76,10 +76,10 @@ public class ForInstructionFactory extends  InstructionFactory {
     	//修改Break和Continue指令的跳转位置,循环出堆
     	ForRelBreakContinue rel =  forStack.pop();
     	for(InstructionGoTo item:rel.breakList){
-    		item.setOffset(result.getCurrentPoint() -  item.getOffset()) ;
+    		item.setOffset(result.getCurrentPoint() -  item.getOffset() + 1) ;
     	}
     	for(InstructionGoTo item:rel.continueList){
-    		item.setOffset(selfAddPoint -  item.getOffset() - 1);
+    		item.setOffset(selfAddPoint -  item.getOffset());
     	}    	
     	
     	//生成作用域结束指令

--- a/src/main/java/com/ql/util/express/instruction/IfInstructionFactory.java
+++ b/src/main/java/com/ql/util/express/instruction/IfInstructionFactory.java
@@ -35,13 +35,23 @@ public class IfInstructionFactory extends  InstructionFactory {
     		children[2] = new ExpressNode(aCompile.getNodeTypeManager().findNodeType("STAT_BLOCK"),null);  
     	}    	
 		int [] finishPoint = new int[children.length];
-   		boolean r1 = aCompile.createInstructionSetPrivate(result,forStack,children[0],false);//condition	
+
+   		boolean r1 = aCompile.createInstructionSetPrivate(result,forStack,children[0],false);//condition
+		InstructionGoToWithCondition goToFalseBody = new InstructionGoToWithCondition(false,
+				0,true);
+		goToFalseBody.setLine(node.getLine());
+		result.addInstruction(goToFalseBody);
 		finishPoint[0] = result.getCurrentPoint();
-		boolean r2 = aCompile.createInstructionSetPrivate(result,forStack,children[1],false);//true		
-		result.insertInstruction(finishPoint[0]+1,new InstructionGoToWithCondition(false,result.getCurrentPoint() - finishPoint[0] + 2,true).setLine(node.getLine()));
+
+		boolean r2 = aCompile.createInstructionSetPrivate(result,forStack,children[1],false);//true
+		InstructionGoTo goToEnd = new InstructionGoTo(0);
+		goToEnd.setLine(node.getLine());
+		result.addInstruction(goToEnd);
+		goToFalseBody.setOffset(result.getCurrentPoint() - finishPoint[0] + 1);
+
 		finishPoint[1] = result.getCurrentPoint();
 		boolean r3 = aCompile.createInstructionSetPrivate(result,forStack,children[2],false);//false
-		result.insertInstruction(finishPoint[1]+1,new InstructionGoTo(result.getCurrentPoint() - finishPoint[1] + 1).setLine(node.getLine()));  		
+		goToEnd.setOffset(result.getCurrentPoint() - finishPoint[1] + 1);
         return r1 || r2 || r3;
 	}
 }

--- a/src/test/java/com/ql/util/express/bugfix/EvalTest.java
+++ b/src/test/java/com/ql/util/express/bugfix/EvalTest.java
@@ -1,0 +1,51 @@
+package com.ql.util.express.bugfix;
+
+import com.ql.util.express.*;
+import com.ql.util.express.instruction.op.OperatorBase;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * 测试引擎嵌套执行
+ */
+public class EvalTest {
+
+    @Test
+    public void evalTest() throws Exception {
+        String evalExpress = "eval('eval(\\'1+1\\')')";
+        final ExpressRunner runner = new ExpressRunner(false,true);
+        runner.addFunction("eval", new OperatorBase() {
+            @Override
+            public OperateData executeInner(InstructionSetContext parent, ArraySwap list) throws Exception {
+                Object res = runner.eval(list.get(0).toString(), parent,
+                        null, true);
+                return new OperateData(res, res.getClass());
+            }
+        });
+
+        Object res = runner.execute(evalExpress, new DefaultContext<String, Object>(), null,
+                false, true);
+        assertEquals(2, res);
+    }
+
+    @Test
+    public void evalUserVariableTest() throws Exception {
+        String evalExpress = "m = 'aaaa';" +
+                "eval('m')";
+        final ExpressRunner runner = new ExpressRunner(false,true);
+        runner.addFunction("eval", new OperatorBase() {
+            @Override
+            public OperateData executeInner(InstructionSetContext parent, ArraySwap list) throws Exception {
+                Object res = runner.eval(list.get(0).toString(), parent,
+                        null, true);
+                return new OperateData(res, res.getClass());
+            }
+        });
+
+        Object res = runner.execute(evalExpress, new DefaultContext<String, Object>(), null,
+                false, true);
+        assertEquals("aaaa", res);
+    }
+
+}

--- a/src/test/java/com/ql/util/express/bugfix/EvalTest.java
+++ b/src/test/java/com/ql/util/express/bugfix/EvalTest.java
@@ -12,6 +12,19 @@ import static org.junit.Assert.*;
 public class EvalTest {
 
     @Test
+    public void macroTest() throws Exception {
+        final ExpressRunner runner = new ExpressRunner(false,true);
+        runner.addMacro("myadd", "a+b");
+
+        String evalExpress = "int a=1;" +
+                "int b = 2;" +
+                "myadd";
+        Object res = runner.execute(evalExpress, new DefaultContext<String, Object>(), null,
+                false, true);
+        System.out.println(res);
+    }
+
+    @Test
     public void evalTest() throws Exception {
         String evalExpress = "eval('eval(\\'1+1\\')')";
         final ExpressRunner runner = new ExpressRunner(false,true);

--- a/src/test/java/com/ql/util/express/test/ForFlowFunctionTest.java
+++ b/src/test/java/com/ql/util/express/test/ForFlowFunctionTest.java
@@ -1,10 +1,9 @@
 package com.ql.util.express.test;
 
+import com.ql.util.express.*;
+import com.ql.util.express.instruction.op.OperatorBase;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.ql.util.express.DefaultContext;
-import com.ql.util.express.ExpressRunner;
 
 
 public class ForFlowFunctionTest {
@@ -20,5 +19,4 @@ public class ForFlowFunctionTest {
 		Object r = runner.execute(express, context, null, false, true);
 		Assert.assertTrue("for循环后面跟着一个函数的时候错误", r.toString().equals("10"));
 	}
-
 }

--- a/src/test/java/com/ql/util/express/test/IfTest.java
+++ b/src/test/java/com/ql/util/express/test/IfTest.java
@@ -38,5 +38,5 @@ public class IfTest {
 			System.out.println("环境结果：" + expressContext);		
 			Assert.assertTrue("表达式执行错误:" + expresses[i][0] + " 期望值：" + expresses[i][1] +" 运算结果：" + result ,expresses[i][1].equals(result == null?"null":result.toString()));
 		}
-	}	
+	}
 }

--- a/src/test/java/com/ql/util/express/test/NewExpressTest.java
+++ b/src/test/java/com/ql/util/express/test/NewExpressTest.java
@@ -69,7 +69,9 @@ public class NewExpressTest {
 				{"int 中国 = 100; int 美国 = 200 ;return 中国 + 美国","300"},
 				{"1 加 1 ","2"},
 				{" 'a' love 'b' love 'c'","c{b{a}b}c"},
-				{"if 1==2 then {return 10}else{return 100}","100"}
+				{"if 1==2 then {return 10}else{return 100}","100"},
+				{"for (i=1;i<10;i++){continue}i", "10"},
+				{"for (i=1;i<10;i++){break}i", "1"}
 		};
 		for(int i=0;i<expresses.length;i++){
 			IExpressContext<String,Object> expressContext = new DefaultContext<String,Object>();
@@ -78,8 +80,9 @@ public class NewExpressTest {
 			runner.addOperator("love","+",new LoveOperator("love"));
 			Object result = runner.execute(expresses[i][0],expressContext, null, false,true);
 			System.out.println("运算结果：" + result);
-			System.out.println("环境结果：" + expressContext);		
-			Assert.assertTrue("表达式执行错误:" + expresses[i][0] + " 期望值：" + expresses[i][1] +" 运算结果：" + result ,expresses[i][1].equals(result == null?"null":result.toString()));
+			System.out.println("环境结果：" + expressContext);
+			Assert.assertEquals("表达式执行错误:" + expresses[i][0] + " 期望值：" + expresses[i][1] + " 运算结果："
+					+ result, expresses[i][1], result == null ? "null" : result.toString());
 		}
 	}
 }


### PR DESCRIPTION
break 和 continue 关键字在下面两种情况下会出现死循环：

```java
for (i=1;i<10;i++){
    continue
}
```

```java
for (i=1;i<10;i++){
    break
}
```

qlexpress 对 continue 和 break 的实现存在 bug，必须要将 break 或者 continue 放在 if 中使用才可以，否则会出现死循环，改 pr 将修复这个问题。