### PR TITLE
使用尾递归优化编译时栈深度过大的问题

### DIFF
--- a/src/main/java/com/ql/util/express/match/QLPattern.java
+++ b/src/main/java/com/ql/util/express/match/QLPattern.java
@@ -1,10 +1,14 @@
 package com.ql.util.express.match;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Stack;
 import java.util.concurrent.atomic.AtomicLong;
 
 import com.ql.util.express.exception.QLCompileException;
+import com.ql.util.express.parse.ExpressNode;
+import com.ql.util.express.parse.NodeType;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -20,13 +24,12 @@ public class QLPattern {
 	}
 	public static QLMatchResult findMatchStatement(INodeTypeManager aManager,QLPatternNode pattern ,List<? extends IDataNode> nodes,int point) throws Exception{
 		AtomicLong maxMatchPoint = new AtomicLong();
-		AtomicLong maxDeep = new AtomicLong(1);
 		QLMatchResultCache resultCache =new QLMatchResultCache(5);
-		ArrayListCache<QLMatchResultTree> arrayListCache = new ArrayListCache<QLMatchResultTree>(50);
-        MatchParamsPack staticParams = new MatchParamsPack(aManager, nodes, maxDeep, maxMatchPoint,resultCache,arrayListCache);
-		QLMatchResult result  = findMatchStatementWithAddRootOptimizeStack(staticParams, pattern, point, true, 1);
+		ArrayListCache arrayListCache = new ArrayListCache(50);
+        MatchParamsPack staticParams = new MatchParamsPack(aManager, nodes, maxMatchPoint,resultCache,arrayListCache);
+		QLMatchResult result  = findMatchStatementWithTailRecursive(staticParams, pattern, null, point, 0, null, null, null);
 		if(printStackDepth) {
-            log.warn("递归堆栈深度:" + maxDeep.longValue() + "  重用QLMatchResult次数:" + resultCache.fetchCount
+            log.warn("重用QLMatchResult次数:" + resultCache.fetchCount
 					+ "  新建QLMatchResult次数:" + resultCache.newCount + "  新建ArrayList数量:" + arrayListCache.newCount);
 
         }
@@ -37,107 +40,59 @@ public class QLPattern {
 		}
 		return result;
 	}
-	private  static QLMatchResult findMatchStatementWithAddRootOptimizeStack(MatchParamsPack staticParams,QLPatternNode pattern ,int point,boolean isRoot,int deep) throws Exception{
+	private  static QLMatchResult findMatchStatementWithTailRecursive(MatchParamsPack staticParams, QLPatternNode pattern, QLPatternNode parentPattern,
+																	  int point, int count, List<QLMatchResultTree> tempList, QLMatchResult tempResult, ReservedVariable reservedVariable) throws Exception{
         
         INodeTypeManager aManager = staticParams.aManager;
         List<? extends IDataNode> nodes = staticParams.nodes;
-        AtomicLong maxMatchPoint = staticParams.maxMatchPoint;
-        AtomicLong maxDeep = staticParams.maxDeep;
-        
-	    //mark maxDeep
-	    deep++;
-		if (deep > maxDeep.longValue()){
-			maxDeep.set(deep);
-		}
-		
-		QLMatchResult result = null;
-		List<QLMatchResultTree> tempList = null;
-		int count = 0;
-		int lastPoint = point;
-		while(true){
-			QLMatchResult tempResult = null;
-			if (pattern.matchMode == MatchMode.DETAIL) {
-				//tempResult = matchDetailOneTime(aManager,pattern,nodes, lastPoint,maxMatchPoint,deep,maxDeep);
 
-				int pointDetail = lastPoint;
-				QLMatchResult resultDetail = null;
-				if(pattern.nodeType == aManager.findNodeType("EOF") && pointDetail == nodes.size()){
-					resultDetail = staticParams.resultCache.fetch().setMatchLastIndex(pointDetail + 1);
-				}else if(pattern.nodeType == aManager.findNodeType("EOF") && pointDetail < nodes.size() && nodes.get(pointDetail).getValue().equals("}") ){
-					resultDetail = staticParams.resultCache.fetch().setMatchLastIndex(pointDetail);
-				}else if(pointDetail == nodes.size() && pattern.nodeType.getPatternNode() != null){
-					resultDetail = findMatchStatementWithAddRootOptimizeStack(staticParams,pattern.nodeType.getPatternNode(),pointDetail,false,deep);
-				}else if( pointDetail < nodes.size()){
-					INodeType tempNodeType = null;
-					if(pattern.nodeType.equals(nodes.get(pointDetail).getTreeType())){
-						tempNodeType = nodes.get(pointDetail).getTreeType();
-					}else if(pattern.nodeType.equals(nodes.get(pointDetail).getNodeType())){
-						tempNodeType = nodes.get(pointDetail).getNodeType();
+		tailRecursive:
+		// 尾递归优化
+		while (true) {
+			if (reservedVariable != null) {
+				pattern = reservedVariable.pattern;
+				parentPattern = reservedVariable.parentPattern;
+				point = reservedVariable.point;
+				count = reservedVariable.count+1;
+				tempList = reservedVariable.tempList;
+				if (reservedVariable instanceof OrReservedVariable) {
+					OrReservedVariable orReservedVariable = (OrReservedVariable)
+							reservedVariable;
+					if (tempResult == null && orReservedVariable.children.hasNext()) {
+						QLPatternNode child = orReservedVariable.children.next();
+						staticParams.recursiveStack.push(orReservedVariable);
+						QLPatternNode oldPattern = pattern;
+
+						pattern = child;
+						parentPattern = oldPattern;
+						count = 0;
+						tempList = null;
+						tempResult = null;
+						reservedVariable = null;
+						continue tailRecursive;
 					}
+				} else if (reservedVariable instanceof AndReservedVariable) {
+					AndReservedVariable andReservedVariable = (AndReservedVariable)
+							reservedVariable;
+					int pointAnd = andReservedVariable.pointAnd;
+					QLMatchResultTree root = andReservedVariable.root;
+					List<QLMatchResultTree> tempListAnd = andReservedVariable
+							.tempListAnd;
+					QLMatchResult tempResultAnd = tempResult;
+					Iterator<QLPatternNode> children = andReservedVariable.children;
+					QLPatternNode lastChild = andReservedVariable.child;
 
-					if(tempNodeType != null){
-						resultDetail = staticParams.resultCache.fetch();
-						resultDetail.addQLMatchResultTree(new QLMatchResultTree(tempNodeType,nodes.get(pointDetail),pattern.targetNodeType));
-						pointDetail = pointDetail + 1;
-						resultDetail.setMatchLastIndex(pointDetail);
-
-						traceLog(pattern,resultDetail,nodes,pointDetail - 1,1);
-					}else if(pattern.nodeType.getPatternNode() != null){
-						resultDetail = findMatchStatementWithAddRootOptimizeStack(staticParams,pattern.nodeType.getPatternNode(),pointDetail,false,deep);
-						if(pattern.targetNodeType != null && resultDetail != null && resultDetail.getMatchSize() >0){
-							if(resultDetail.getMatchSize() > 1){
-								throw new QLCompileException("设置了类型转换的语法，只能有一个根节点");
-							}
-							resultDetail.getMatchs().get(0).targetNodeType = pattern.targetNodeType;
-						}
-					}
-					if(pattern.blame == true){//取返处理
-						if( resultDetail == null){
-							resultDetail = staticParams.resultCache.fetch();
-							resultDetail.addQLMatchResultTree(new QLMatchResultTree(tempNodeType,nodes.get(pointDetail),null));
-							pointDetail = pointDetail + 1;
-							resultDetail.setMatchLastIndex(pointDetail);
-						}else{
-							resultDetail = null;
-						}
-					}
-				}
-				if(resultDetail != null && resultDetail.getMatchLastIndex() > maxMatchPoint.longValue()){
-					maxMatchPoint.set(resultDetail.getMatchLastIndex());
-				}
-
-				tempResult = resultDetail;
-
-
-			}else if (pattern.matchMode == MatchMode.AND) {
-				//tempResult = matchAndOneTime(aManager,pattern,nodes, lastPoint,maxMatchPoint,deep,maxDeep);
-
-				int orgiPoint = lastPoint;
-				int pointAnd = lastPoint;
-
-				QLMatchResultTree root = null;
-				int matchCount =0;//用于调试日志的输出
-				List<QLMatchResultTree> tempListAnd =null;
-				boolean isBreak = false;
-				for (QLPatternNode item : pattern.children) {
-					if(pointAnd > nodes.size()){
-						isBreak = true;
-						break;
-					}
-					QLMatchResult tempResultAnd = findMatchStatementWithAddRootOptimizeStack(staticParams,item,
-							pointAnd,false,deep);
-					if (tempResultAnd != null) {
-						if(tempResultAnd.getMatchSize() > 0){
-							matchCount = matchCount + 1;
-						}
+					boolean notMatch = tempResultAnd == null ||
+							(children.hasNext() && pointAnd > nodes.size());
+					if (!notMatch) {
 						if(tempListAnd == null){
 							tempListAnd = staticParams.arrayListCache.fetch();
 						}
 						pointAnd = tempResultAnd.getMatchLastIndex();
-						if (item.isTreeRoot == true && tempResultAnd.getMatchSize() >0) {
+						if (lastChild.isTreeRoot && tempResultAnd.getMatchSize() > 0) {
 							if (tempResultAnd.getMatchSize() > 1) {
-                                throw new QLCompileException("根节点的数量必须是1");
-                            }
+								throw new QLCompileException("根节点的数量必须是1");
+							}
 							if (root == null) {
 								QLMatchResultTree tempTree = tempResultAnd.getMatchs().get(0);
 								while(tempTree.getLeft()!= null && tempTree.getLeft().size()>0){
@@ -155,214 +110,410 @@ public class QLPattern {
 							tempListAnd.addAll(tempResultAnd.getMatchs());
 						}
 						//归还QLMatchResult对象到对象池
-						if (tempResultAnd!= null) {
-							staticParams.resultCache.sendBack(tempResultAnd);
-							tempResultAnd = null;
+						staticParams.resultCache.sendBack(tempResultAnd);
+						if (children.hasNext()) {
+							QLPatternNode child = children.next();
+							andReservedVariable.child = child;
+							andReservedVariable.pointAnd = pointAnd;
+							andReservedVariable.root = root;
+							andReservedVariable.tempListAnd = tempListAnd;
+							staticParams.recursiveStack.push(andReservedVariable);
+							QLPatternNode oldPattern = pattern;
+
+							// 继续递归
+							pattern = child;
+							parentPattern = oldPattern;
+							point = pointAnd;
+							count = 0;
+							tempList = null;
+							tempResult = null;
+							reservedVariable = null;
+							continue tailRecursive;
 						}
-					}else{
-						isBreak = true;
-						break;
+					}
+
+					// 聚合 and 匹配的结果
+					if(root != null){
+						tempListAnd.add(root);
+					}
+					if (notMatch) {
+						tempResult = null;
+					} else {
+						tempResult = staticParams.resultCache.fetch()
+								.addQLMatchResultTreeList(tempListAnd);
+						tempResult.setMatchLastIndex(pointAnd);
+						traceLog(pattern,tempResult,nodes,point);
+					}
+
+					if (tempListAnd != null){
+						staticParams.arrayListCache.sendBack(tempListAnd);
 					}
 				}
-				if(root != null){
-					tempListAnd.add(root);
-				}
-
-				if(isBreak == false){
-					tempResult = staticParams.resultCache.fetch().addQLMatchResultTreeList(tempListAnd);
-					tempResult.setMatchLastIndex(pointAnd);
-					traceLog(pattern,tempResult,nodes,orgiPoint,matchCount);
-				}else{
-					tempResult = null;
-				}
-
-				if (tempListAnd != null){
-					staticParams.arrayListCache.sendBack(tempListAnd);
-				}
-
-
-
-			}else if (pattern.matchMode == MatchMode.OR) {
-				//tempResult = matchOrOneTime(aManager,pattern,nodes, lastPoint,maxMatchPoint,deep,maxDeep);
-
-				for (QLPatternNode item : pattern.children) {
-					tempResult = findMatchStatementWithAddRootOptimizeStack(staticParams,item, lastPoint, false, deep);
-					if (tempResult != null) {
-						break;
-					}
-				}
-
-			}else{
-				throw new QLCompileException("不正确的类型：" + pattern.matchMode.toString());
 			}
 
-			if(tempResult == null){
-				if(count >= pattern.minMatchNum && count <=pattern.maxMatchNum){
-					//正确匹配
-					result = staticParams.resultCache.fetch();
-					if(tempList != null){
-						result.addQLMatchResultTreeList(tempList);
-					}
-					result.setMatchLastIndex(lastPoint);
-				}else{
-					result = null;
-				}
-				break;
-			}else{
+			if (count > 0 && tempResult != null) {
 				if(tempList == null){
-					tempList =staticParams.arrayListCache.fetch();
+					tempList = staticParams.arrayListCache.fetch();
 				}
-				lastPoint = tempResult.getMatchLastIndex();
-				if(pattern.isTreeRoot == true){
-					if(tempResult.getMatchSize() > 1){
+				point = tempResult.getMatchLastIndex();
+				if(pattern.isTreeRoot){
+					if (tempResult.getMatchSize() > 1){
 						throw new QLCompileException("根节点的数量必须是1");
 					}
-					if(tempList.size() == 0){
-						tempList.addAll(tempResult.getMatchs());
-					}else{	
+					if (tempList.size() > 0) {
 						tempResult.getMatchs().get(0).addLeftAll(tempList);
 						//为了能回收QLMatchResult对象,这个地方必须进行数组拷贝
 						tempList = staticParams.arrayListCache.fetch();
-						tempList.addAll(tempResult.getMatchs());
 					}
-				}else{
-				   tempList.addAll(tempResult.getMatchs());
 				}
-			}
 
-			/**  归还QLMatchResult  */
-			if(tempResult != null){
+				// 为了能回收QLMatchResult对象,这个地方必须进行数组拷贝
+				// 在这之前 tempList 一定是个空列表
+				tempList.addAll(tempResult.getMatchs());
+
+				/*  归还QLMatchResult  */
 				staticParams.resultCache.sendBack(tempResult);
-				tempResult = null;
 			}
 
-			count = count + 1;			
-			if(count == pattern.maxMatchNum){
+			boolean lastUnmatch = count > 0 && tempResult == null;
+			int parentPoint = point;
+			if (count < pattern.maxMatchNum && !lastUnmatch) {
+
+				tempResult = null;
+				if (pattern.matchMode == MatchMode.DETAIL) {
+					QLMatchResult resultDetail = null;
+					if(pattern.nodeType == aManager.findNodeType("EOF") && point == nodes.size()){
+						resultDetail = staticParams.resultCache.fetch().setMatchLastIndex(point + 1);
+					}else if(pattern.nodeType == aManager.findNodeType("EOF") && point < nodes.size() && nodes.get(point).getValue().equals("}") ){
+						resultDetail = staticParams.resultCache.fetch().setMatchLastIndex(point);
+					}else if(point == nodes.size() && pattern.nodeType.getPatternNode() != null){
+						QLPatternNode oldPattern = pattern;
+
+						pushToStackDetail(staticParams.recursiveStack, pattern, parentPattern, point, count, tempList);
+						pattern = pattern.nodeType.getPatternNode();
+						parentPattern = oldPattern;
+						count = 0;
+						tempList = null;
+						tempResult = null;
+						reservedVariable = null;
+						continue tailRecursive;
+					} else if(point < nodes.size()) {
+						INodeType tempNodeType = null;
+						if(pattern.nodeType.equals(nodes.get(point).getTreeType())){
+							tempNodeType = nodes.get(point).getTreeType();
+						}else if(pattern.nodeType.equals(nodes.get(point).getNodeType())){
+							tempNodeType = nodes.get(point).getNodeType();
+						}
+
+						if(tempNodeType != null){
+							resultDetail = staticParams.resultCache.fetch();
+							resultDetail.addQLMatchResultTree(new QLMatchResultTree(tempNodeType,nodes.get(point),pattern.targetNodeType));
+							resultDetail.setMatchLastIndex(point+1);
+
+							traceLog(pattern,resultDetail,nodes,point);
+						}else if(pattern.nodeType.getPatternNode() != null){
+							QLPatternNode oldPattern = pattern;
+
+							pushToStackDetail(staticParams.recursiveStack, pattern, parentPattern, point, count, tempList);
+							pattern = pattern.nodeType.getPatternNode();
+							parentPattern = oldPattern;
+							count = 0;
+							tempList = null;
+							tempResult = null;
+							reservedVariable = null;
+							continue tailRecursive;
+						}
+					}
+
+					tempResult = resultDetail;
+				}else if (pattern.matchMode == MatchMode.AND) {
+
+					Iterator<QLPatternNode> children = pattern.children.iterator();
+					if (children.hasNext()) {
+						QLPatternNode item = children.next();
+						QLPatternNode oldPattern = pattern;
+
+						pushToStackAnd(staticParams.recursiveStack, pattern, parentPattern, point,
+								count, tempList, children, item,
+								point, null, null);
+						pattern = item;
+						parentPattern = oldPattern;
+						count = 0;
+						tempList = null;
+						tempResult = null;
+						reservedVariable = null;
+						continue tailRecursive;
+					}
+
+				} else if (pattern.matchMode == MatchMode.OR) {
+
+					Iterator<QLPatternNode> children = pattern.children.iterator();
+					if (children.hasNext()) {
+						QLPatternNode oldPattern = pattern;
+
+						pushToStackOr(staticParams.recursiveStack, pattern, parentPattern, point, count, tempList, children);
+						pattern = children.next();
+						parentPattern = oldPattern;
+						count = 0;
+						tempList = null;
+						tempResult = null;
+						reservedVariable = null;
+						continue tailRecursive;
+					}
+
+				} else {
+					throw new QLCompileException("不正确的类型：" + pattern.matchMode.toString());
+				}
+
+				count = count + 1;
+				reservedVariable = null;
+				continue tailRecursive;
+			}
+			count = lastUnmatch? count - 1: count;
+			QLMatchResult result;
+			if (count >= pattern.minMatchNum && count <= pattern.maxMatchNum) {
+				//正确匹配
 				result = staticParams.resultCache.fetch();
-				if(tempList != null){
+				if (tempList != null) {
 					result.addQLMatchResultTreeList(tempList);
 				}
-				result.setMatchLastIndex(lastPoint);
-				break;
+				result.setMatchLastIndex(point);
+			} else {
+				result = null;
 			}
-		}
-		if(result != null && pattern.isSkip == true){
-			//忽略跳过所有匹配到的节点
-			result.getMatchs().clear();
-		}
 
-		if(result != null && result.getMatchSize() >0 && pattern.rootNodeType != null){
-			QLMatchResultTree tempTree = new QLMatchResultTree(pattern.rootNodeType,nodes.get(0).createExpressNode(pattern.rootNodeType,null));
-			tempTree.addLeftAll(result.getMatchs());
-			result.getMatchs().clear();
-			result.getMatchs().add(tempTree);
-		}
-		if (tempList != null){
+			if (tempList != null) {
 				staticParams.arrayListCache.sendBack(tempList);
 			}
-		return result;
+
+			result = handleResult(staticParams, result, pattern, parentPattern, parentPoint);
+			if (staticParams.recursiveStack.isEmpty()) {
+				return result;
+			}
+
+			reservedVariable = staticParams.recursiveStack.pop();
+			tempResult = result;
+			continue tailRecursive;
+		}
+	}
+
+	private static QLMatchResult handleResultNoParent(MatchParamsPack staticParams, QLMatchResult originResult, QLPatternNode pattern) throws Exception {
+		if(originResult != null && pattern.isSkip){
+			//忽略跳过所有匹配到的节点
+			originResult.getMatchs().clear();
+		}
+
+		if(originResult != null && originResult.getMatchSize() >0 && pattern.rootNodeType != null){
+			QLMatchResultTree tempTree = new QLMatchResultTree(pattern.rootNodeType,
+					new ExpressNode((NodeType) pattern.rootNodeType,null));
+			tempTree.addLeftAll(originResult.getMatchs());
+			originResult.getMatchs().clear();
+			originResult.getMatchs().add(tempTree);
+		}
+
+		return originResult;
+	}
+
+	private static QLMatchResult handleResult(MatchParamsPack staticParams, QLMatchResult originResult, QLPatternNode pattern, QLPatternNode parentPattern, int parentPoint) throws Exception {
+		originResult = handleResultNoParent(staticParams, originResult, pattern);
+
+		if (parentPattern != null) {
+			if (parentPattern.matchMode == MatchMode.DETAIL) {
+				if (parentPoint < staticParams.nodes.size()) {
+					if(parentPattern.targetNodeType != null && originResult != null && originResult.getMatchSize() >0){
+						if(originResult.getMatchSize() > 1){
+							throw new QLCompileException("设置了类型转换的语法，只能有一个根节点");
+						}
+						originResult.getMatchs().get(0).targetNodeType = parentPattern.targetNodeType;
+					}
+					if(parentPattern.blame){//取反处理
+						if(originResult == null){
+							originResult = staticParams.resultCache.fetch();
+							originResult.addQLMatchResultTree(new QLMatchResultTree(null,staticParams.nodes.get(parentPoint),null));
+							originResult.setMatchLastIndex(parentPoint + 1);
+						}else{
+							originResult = null;
+						}
+					}
+				}
+				if(originResult != null && originResult.getMatchLastIndex() > staticParams.maxMatchPoint.longValue()){
+					staticParams.maxMatchPoint.set(originResult.getMatchLastIndex());
+				}
+			}
+		}
+
+		return originResult;
 	}
 
 	public static void traceLog(QLPatternNode pattern, QLMatchResult result,
-			List<? extends IDataNode> nodes, int point,int matchCount) {
-		if (log.isTraceEnabled() && (pattern.matchMode ==MatchMode.DETAIL || pattern.matchMode == MatchMode.AND && matchCount > 1 && pattern.name.equals("ANONY_PATTERN") == false )) {
+			List<? extends IDataNode> nodes, int point) {
+		if (log.isTraceEnabled() && (pattern.matchMode ==MatchMode.DETAIL || pattern.matchMode == MatchMode.AND && !pattern.name.equals("ANONY_PATTERN") )) {
 			log.trace("匹配--" + pattern.name +"[" + point  + ":" + (result.getMatchLastIndex() -1)+ "]:" + pattern);
 		}
 	}
-	
+
+	private static void pushToStackDetail(Stack<ReservedVariable> recursiveStack, QLPatternNode pattern, QLPatternNode parentPattern, int point, int count, List<QLMatchResultTree> tempList) {
+		DetailReservedVariable detailReservedVariable = new DetailReservedVariable();
+		detailReservedVariable.pattern = pattern;
+		detailReservedVariable.parentPattern = parentPattern;
+		detailReservedVariable.point = point;
+		detailReservedVariable.count = count;
+		detailReservedVariable.tempList = tempList;
+		recursiveStack.push(detailReservedVariable);
+	}
+
+	private static void pushToStackOr(Stack<ReservedVariable> recursiveStack, QLPatternNode pattern, QLPatternNode parentPattern, int point, int count, List<QLMatchResultTree> tempList, Iterator<QLPatternNode> children) {
+		OrReservedVariable orReservedVariable = new OrReservedVariable();
+		orReservedVariable.pattern = pattern;
+		orReservedVariable.parentPattern = parentPattern;
+		orReservedVariable.point = point;
+		orReservedVariable.count = count;
+		orReservedVariable.tempList = tempList;
+		orReservedVariable.children = children;
+		recursiveStack.push(orReservedVariable);
+	}
+
+	private static void pushToStackAnd(Stack<ReservedVariable> recursiveStack, QLPatternNode pattern, QLPatternNode parentPattern, int point, int count, List<QLMatchResultTree> tempList, Iterator<QLPatternNode> children, QLPatternNode child, int pointAnd, QLMatchResultTree root, List<QLMatchResultTree> tempListAnd) {
+		AndReservedVariable andReservedVariable = new AndReservedVariable();
+		andReservedVariable.pattern = pattern;
+		andReservedVariable.parentPattern = parentPattern;
+		andReservedVariable.point = point;
+		andReservedVariable.count = count;
+		andReservedVariable.tempList = tempList;
+		andReservedVariable.children = children;
+		andReservedVariable.child = child;
+		andReservedVariable.pointAnd = pointAnd;
+		andReservedVariable.root = root;
+		andReservedVariable.tempListAnd = tempListAnd;
+		recursiveStack.push(andReservedVariable);
+	}
+
+	private static class ReservedVariable {
+		QLPatternNode pattern;
+		QLPatternNode parentPattern;
+		int point;
+		int count;
+		List<QLMatchResultTree> tempList;
+	}
+
+	private static class DetailReservedVariable extends ReservedVariable {
+	}
+
+	private static class OrReservedVariable extends ReservedVariable {
+		Iterator<QLPatternNode> children;
+	}
+
+	private static class AndReservedVariable extends ReservedVariable {
+		Iterator<QLPatternNode> children;
+		QLPatternNode child;
+		int pointAnd;
+		QLMatchResultTree root;
+		List<QLMatchResultTree> tempListAnd;
+	}
+
 	public static class MatchParamsPack
     {
         INodeTypeManager aManager;
         List<? extends IDataNode> nodes;
-        AtomicLong maxDeep;
         AtomicLong maxMatchPoint;
 		QLMatchResultCache resultCache;
 		ArrayListCache arrayListCache;
-        public MatchParamsPack(INodeTypeManager aManager, List<? extends IDataNode> nodes, AtomicLong maxDeep, AtomicLong maxMatchPoint,QLMatchResultCache aResultCache,ArrayListCache aArrayListCache) {
+		Stack<ReservedVariable> recursiveStack = new Stack<ReservedVariable>();
+
+        public MatchParamsPack(INodeTypeManager aManager, List<? extends IDataNode> nodes, AtomicLong maxMatchPoint,QLMatchResultCache aResultCache,ArrayListCache aArrayListCache) {
             this.aManager = aManager;
             this.nodes = nodes;
-            this.maxDeep = maxDeep;
             this.maxMatchPoint = maxMatchPoint;
 			this.resultCache = aResultCache;
 			this.arrayListCache = aArrayListCache;
         }
     }
 
-	public  static class QLMatchResultCache {
+    public static abstract class BaseCache<T> {
 		public  int newCount =0;
 		public  int fetchCount =0;
 
-		private QLMatchResult[] cache ;
-		private int len= 10;
-		private int point =9;
-		public QLMatchResultCache(int aLen){
+		private T[] cache ;
+		private int len;
+		private int point;
+
+		public BaseCache(int aLen) {
 			this.len = aLen;
 			this.point = this.len -1;
-			cache = new QLMatchResult[this.len ];
-			for (int i=0;i<this.len;i++){
-				cache[i] = new QLMatchResult();
+			cache = newCacheArray(this.len);
+			for (int i = 0; i < this.len; i++) {
+				cache[i] = newInstance();
 			}
 		}
 
-		public QLMatchResult fetch() {
-			QLMatchResult result = null;
+		public T fetch() {
+			T result = null;
 			if (point >=0) {
 				result = cache[point];
 				cache[point] = null;
 				point = point - 1;
 				fetchCount++;
 			} else {
-				result = new QLMatchResult();
+				result = newInstance();
 				newCount++;
 			}
 			return result;
 		}
-		public void sendBack(QLMatchResult result){
+
+		public void sendBack(T result){
 			if (this.point <this.len -1){
 				this.point = this.point + 1;
 				cache[this.point] = result;
-				cache[this.point].clear();
+				clear(cache[this.point]);
 			}
 		}
 
+		abstract T[] newCacheArray(int num);
+		abstract T newInstance();
+		abstract void clear(T sendBackObj);
 	}
 
-	public  static class ArrayListCache<T> {
+	public static class QLMatchResultCache extends BaseCache<QLMatchResult> {
 
-		public  int newCount =0;
-		public  int fetchCount =0;
-
-		private List<T>[] cache ;
-		private int len= 50;
-		private int point =49;
-		public ArrayListCache(int aLen){
-			this.len = aLen;
-			this.point = this.len -1;
-			cache = new List[this.len];
-			for (int i=0;i<this.len;i++){
-				cache[i] = new ArrayList<T>();
-			}
+		public QLMatchResultCache(int aLen) {
+			super(aLen);
 		}
 
-		public List<T> fetch() {
-			List<T> result = null;
-			if (point >=0) {
-				result = cache[point];
-				cache[point] = null;
-				point = point - 1;
-				fetchCount++;
-			} else {
-				result = new ArrayList<T>();
-				newCount++;
-			}
-			return result;
+		@Override
+		QLMatchResult[] newCacheArray(int num) {
+			return new QLMatchResult[num];
 		}
-		public void sendBack(List<T> result){
-			if (this.point <this.len -1){
-				this.point = this.point + 1;
-				cache[this.point] = result;
-				cache[this.point].clear();
-			}
+
+		@Override
+		QLMatchResult newInstance() {
+			return new QLMatchResult();
+		}
+
+		@Override
+		void clear(QLMatchResult sendBackObj) {
+			sendBackObj.clear();
+		}
+	}
+
+	public static class ArrayListCache extends BaseCache<List> {
+
+		public ArrayListCache(int aLen) {
+			super(aLen);
+		}
+
+		@Override
+		List[] newCacheArray(int num) {
+			return new List[num];
+		}
+
+		@Override
+		List newInstance() {
+			return new ArrayList();
+		}
+
+		@Override
+		void clear(List sendBackObj) {
+			sendBackObj.clear();
 		}
 	}
 }

--- a/src/test/java/com/ql/util/express/test/IfTest.java
+++ b/src/test/java/com/ql/util/express/test/IfTest.java
@@ -1,5 +1,6 @@
 package com.ql.util.express.test;
 
+import com.ql.util.express.match.QLPattern;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -38,5 +39,18 @@ public class IfTest {
 			System.out.println("环境结果：" + expressContext);		
 			Assert.assertTrue("表达式执行错误:" + expresses[i][0] + " 期望值：" + expresses[i][1] +" 运算结果：" + result ,expresses[i][1].equals(result == null?"null":result.toString()));
 		}
-	}	
+	}
+
+	@Test
+	public void complexIf() {
+		QLPattern.printStackDepth = true;
+		String express = "if (secondProd in (\"9102\", \"9105\")\n" +
+				"        && (((tradeProduct == \"S_STANDARD\" || tradeProduct == \"S_PHASE_STANDARD\") && (bizIdentity == \"trade10001\" || bizIdentity == \"forex10004\"))\n" +
+				"            || (deliveryProductCode == \"TB_FACE_TO_FACE_PAY\" && bizIdentity == \"trade20001\")\n" +
+				"            || (deliveryProductCode == \"TB_FUND_PRE_AUTH\" && bizIdentity == \"order10010\"))) {\n" +
+				"            return \"AMT_TAOXI_TEMP\";\n" +
+				"    }";
+		ExpressRunner runner = new ExpressRunner(false,true);
+		runner.checkSyntax(express);
+	}
 }


### PR DESCRIPTION
虽然在 3.2.1 时 qlexpress 似乎优化过一次栈的使用，但是依旧栈的深度依旧很深，比如下面一段简单的脚本，最大栈的深度就高达 152：

```java
if (secondProd in ("9102", "9105")
        && (((tradeProduct == "S_STANDARD" || tradeProduct == "S_PHASE_STANDARD") && (bizIdentity == "trade10001" || bizIdentity == "forex10004"))
            || (deliveryProductCode == "TB_FACE_TO_FACE_PAY" && bizIdentity == "trade20001")
            || (deliveryProductCode == "TB_FUND_PRE_AUTH" && bizIdentity == "order10010"))) {
            return "AMT_TAOXI_TEMP";
    }
```

线上稍微长一些的脚本就有很大的 stackOverflow 风险。所以我这里将语法分析部分改成了尾递归，跑过了所有单测，能够彻底解决编译栈深度过深的问题