### PR TITLE
支持 java8 lambda 表达式

### DIFF
--- a/src/main/java/com/ql/util/express/ExpressRunner.java
+++ b/src/main/java/com/ql/util/express/ExpressRunner.java
@@ -131,6 +131,9 @@ public class ExpressRunner {
 		this.parse =  new ExpressParse(manager,this.expressResourceLoader,this.isPrecise);
 		rootExpressPackage.addPackage("java.lang");
 		rootExpressPackage.addPackage("java.util");
+
+		// 默认引入 java8 stream api, jdk 版本低于 8 也不会有影响, 因为是运行时动态取的
+		rootExpressPackage.addPackage("java.util.stream");
 		this.addSystemFunctions();
         this.addSystemOperators();
 	}

--- a/src/main/java/com/ql/util/express/QLambda.java
+++ b/src/main/java/com/ql/util/express/QLambda.java
@@ -1,0 +1,74 @@
+package com.ql.util.express;
+
+import com.ql.util.express.instruction.OperateDataCacheManager;
+import com.ql.util.express.instruction.opdata.OperateDataLocalVar;
+import org.apache.commons.logging.Log;
+
+import java.util.List;
+
+/**
+ * 代表一个 lambda 表达式
+ */
+public class QLambda {
+
+    private final InstructionSet functionSet;
+
+    private final RunEnvironment environment;
+
+    private final List<String> errorList;
+
+    private final Log log;
+
+    public QLambda(InstructionSet functionSet, RunEnvironment environment, List<String> errorList, Log log) {
+        this.functionSet = functionSet;
+        this.environment = environment;
+        this.errorList = errorList;
+        this.log = log;
+    }
+
+    public Object call(Object ... params) throws Exception {
+        InstructionSetContext context = OperateDataCacheManager.fetchInstructionSetContext(
+                true, environment.getContext().getExpressRunner(), environment.getContext(),
+                environment.getContext().getExpressLoader(), environment.getContext().isSupportDynamicFieldName());
+        OperateDataLocalVar[] vars = functionSet.getParameters();
+        for (int i = 0; i < vars.length; i++) {
+            OperateDataLocalVar var = OperateDataCacheManager.fetchOperateDataLocalVar(vars[i].getName(),
+                    params.length <= i ? Object.class: params[i] == null? Object.class: params[i].getClass());
+            context.addSymbol(var.getName(), var);
+            var.setObject(context, params.length > i? params[i]: null);
+        }
+
+        return InstructionSetRunner.execute(functionSet, context, errorList, environment.isTrace(),
+                false, true, log);
+    }
+
+    /**
+     * 为了用起来更像 java 的 lambda 表达式而增加额外的一些方法
+     */
+    public void run() throws Exception {
+        call();
+    }
+
+    /**
+     * Consumer
+     * BiConsumer
+     */
+    public void accept(Object ... params) throws Exception {
+        call(params);
+    }
+
+    /**
+     * Function
+     * BiFunction
+     */
+    public Object apply(Object... params) throws Exception {
+        return call(params);
+    }
+
+    /**
+     * Supplier
+     */
+    public Object get() throws Exception {
+        return call();
+    }
+}

--- a/src/main/java/com/ql/util/express/QLambdaInvocationHandler.java
+++ b/src/main/java/com/ql/util/express/QLambdaInvocationHandler.java
@@ -1,0 +1,20 @@
+package com.ql.util.express;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+public class QLambdaInvocationHandler implements InvocationHandler {
+    private final QLambda qLambda;
+
+    public QLambdaInvocationHandler(QLambda qLambda) {
+        this.qLambda = qLambda;
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        return Modifier.isAbstract(method.getModifiers())? qLambda.call(args):
+                // 为了应对 toString 方法
+                method.getReturnType() == String.class? "QLambdaProxy": null;
+    }
+}

--- a/src/main/java/com/ql/util/express/instruction/LambdaInstructionFactory.java
+++ b/src/main/java/com/ql/util/express/instruction/LambdaInstructionFactory.java
@@ -1,0 +1,55 @@
+package com.ql.util.express.instruction;
+
+import com.ql.util.express.ExpressRunner;
+import com.ql.util.express.InstructionSet;
+import com.ql.util.express.exception.QLException;
+import com.ql.util.express.instruction.detail.InstructionLoadLambda;
+import com.ql.util.express.instruction.opdata.OperateDataLocalVar;
+import com.ql.util.express.parse.ExpressNode;
+
+import java.util.Stack;
+
+public class LambdaInstructionFactory extends InstructionFactory {
+
+    private static final String LAMBDA_NODE_NAME = "LAMBDA";
+
+    @Override
+    public boolean createInstruction(ExpressRunner aCompile, InstructionSet result, Stack<ForRelBreakContinue> forStack,
+                                     ExpressNode node, boolean isRoot) throws Exception {
+        ExpressNode[] children = node.getChildren();
+        if (children.length != 2) {
+            throw new QLException("lambda 操作符需要2个操作数");
+
+        }
+
+        InstructionSet lambdaSet = new InstructionSet(InstructionSet.TYPE_FUNCTION);
+
+        // lambda 参数列表
+        ExpressNode lambdaVarDefine = children[0];
+        if ("CHILD_EXPRESS".equals(lambdaVarDefine.getNodeType().getName())) {
+            // 带括号的参数写法
+            for (ExpressNode varDefine : lambdaVarDefine.getChildren()) {
+                OperateDataLocalVar tmpVar = new OperateDataLocalVar(varDefine.getValue(), null);
+                lambdaSet.addParameter(tmpVar);
+            }
+        } else {
+            // 单参数省略括号的写法
+            lambdaSet.addParameter(new OperateDataLocalVar(lambdaVarDefine.getValue(), null));
+        }
+
+        // lambda 逻辑体
+        ExpressNode lambdaBodyRoot = new ExpressNode(aCompile.getNodeTypeManager()
+                .findNodeType("FUNCTION_DEFINE"), LAMBDA_NODE_NAME);
+        if ("STAT_BLOCK".equals(node.getNodeType().getName())) {
+            for (ExpressNode tempNode : children[1].getChildren()) {
+                lambdaBodyRoot.addLeftChild(tempNode);
+            }
+        } else {
+            lambdaBodyRoot.addLeftChild(children[1]);
+        }
+
+        aCompile.createInstructionSet(lambdaBodyRoot, lambdaSet);
+        result.addInstruction(new InstructionLoadLambda(lambdaSet));
+        return false;
+    }
+}

--- a/src/main/java/com/ql/util/express/instruction/detail/InstructionLoadLambda.java
+++ b/src/main/java/com/ql/util/express/instruction/detail/InstructionLoadLambda.java
@@ -1,0 +1,32 @@
+package com.ql.util.express.instruction.detail;
+
+import com.ql.util.express.InstructionSet;
+import com.ql.util.express.QLambda;
+import com.ql.util.express.RunEnvironment;
+import com.ql.util.express.instruction.OperateDataCacheManager;
+
+import java.util.List;
+
+/**
+ * 将一个 QLambda 加载到栈上
+ */
+public class InstructionLoadLambda extends Instruction {
+    private final InstructionSet lambdaSet;
+
+    public InstructionLoadLambda(InstructionSet lambdaSet) {
+        this.lambdaSet = lambdaSet;
+    }
+
+    @Override
+    public void execute(RunEnvironment environment, List<String> errorList) throws Exception {
+        environment.push(
+                OperateDataCacheManager.fetchOperateData(new QLambda(lambdaSet, environment, errorList, log), null)
+        );
+        environment.programPointAddOne();
+    }
+
+    @Override
+    public String toString() {
+        return "Load Lambda " + lambdaSet.toString() + "Lambda End";
+    }
+}

--- a/src/main/java/com/ql/util/express/match/QLPatternNode.java
+++ b/src/main/java/com/ql/util/express/match/QLPatternNode.java
@@ -127,7 +127,7 @@ public class QLPatternNode{
 			//log.trace("分解匹配模式[LEVEL="+ this.level +"]START:" + str + this.orgiContent);
 		}
 		String orgStr = this.orgiContent;
-		if(orgStr.equals("(") || orgStr.equals(")") || orgStr.equals("|")||orgStr.equals("||")||orgStr.equals("/**") || orgStr.equals("**/")||orgStr.equals("*")){
+		if(orgStr.equals("(") || orgStr.equals(")") || orgStr.equals("|")||orgStr.equals("||")||orgStr.equals("/**") || orgStr.equals("**/")||orgStr.equals("*") || orgStr.equals("->")){
 			this.matchMode = MatchMode.DETAIL;
 			this.nodeType = this.nodeTypeManager.findNodeType(orgStr);
 			return ;

--- a/src/main/java/com/ql/util/express/parse/KeyWordDefine4Java.java
+++ b/src/main/java/com/ql/util/express/parse/KeyWordDefine4Java.java
@@ -7,7 +7,9 @@ public class KeyWordDefine4Java {
 			 "+", "-","*", "/", "%","++", "--",//四则运算：
 			 ".",",",":",";","(", ")", "{", "}", "[", "]","?",//分隔符号
 			 "!","<", ">", "<=", ">=", "==","!=","&&","||",//Boolean运算符号
-			 "=","/**","**/"
+			 "=","/**","**/",
+			 // lambda 表达式
+			 "->"
 	};
 	public  String[] keyWords = new String[] {
 			 "mod","nor","in",
@@ -30,6 +32,7 @@ public class KeyWordDefine4Java {
 				"OR:TYPE=WORDDEF,DEFINE=||",
 				"LEFT_COMMENT:TYPE=WORDDEF,DEFINE=/**",
 				"RIGHT_COMMENT:TYPE=WORDDEF,DEFINE=**/",
+				"ARROW:TYPE=WORDDEF,DEFINE=->",
 				"MULTI:TYPE=WORDDEF,DEFINE=*",
 				
 				
@@ -83,7 +86,7 @@ public class KeyWordDefine4Java {
 				"ARRAY_CALL:TYPE=EXPRESS,DEFINE=(FUNCTION_CALL|OBJECT_CALL)$([->ARRAY_CALL^$EXPRESS$]~)^*$(METHOD_CALL|FIELD_CALL)^*",
 
 				
-				"CAST_CALL:TYPE=EXPRESS,DEFINE=(LEFT_BRACKET~$CONST_CLASS$RIGHT_BRACKET~#cast)^*$ARRAY_CALL",
+				"CAST_CALL:TYPE=EXPRESS,DEFINE=(LEFT_BRACKET~$CONST_CLASS$RIGHT_BRACKET~#cast)^*$((LAMBDA#LAMBDA)|ARRAY_CALL)",
 				"EXPRESS_OP_L1:TYPE=EXPRESS,DEFINE=OP_LEVEL1^*$CAST_CALL",
 				"EXPRESS_OP_L2:TYPE=EXPRESS,DEFINE=EXPRESS_OP_L1$OP_LEVEL2^*",
 				"EXPRESS_OP_L3:TYPE=EXPRESS,DEFINE=EXPRESS_OP_L2$(OP_LEVEL3^$EXPRESS_OP_L2)^*",
@@ -126,7 +129,9 @@ public class KeyWordDefine4Java {
 				"COMMENT:TYPE=BLOCK,DEFINE=LEFT_COMMENT$(RIGHT_COMMENT@)*$RIGHT_COMMENT#COMMENT",
 				
 				"STATEMENT:TYPE=STATEMENT,DEFINE=COMMENT|STAT_IFELSE|STAT_IF|STAT_IFELSE_JAVA|STAT_IF_JAVA|STAT_FOR|STAT_MACRO|STAT_FUNCTION|STAT_CLASS|STAT_SEMICOLON",
-				
+				"LAMBDA:TYPE=EXPRESS,DEFINE=(LAMBDA_PARAMETER_DEFINE|ID)$ARROW~$LAMBDA_BODY",
+				"LAMBDA_BODY:TYPE=BLOCK,DEFINE=STAT_BLOCK|EXPRESS",
+				"LAMBDA_PARAMETER_DEFINE:TYPE=STATEMENT,DEFINE=LEFT_BRACKET->CHILD_EXPRESS^$(RIGHT_BRACKET~|(ID->CONST_STRING$(,~$ID->CONST_STRING)*$RIGHT_BRACKET~))",
 				"STAT_BLOCK:TYPE=BLOCK,DEFINE={->STAT_BLOCK^$STAT_LIST$}~",
 				"STAT_LIST:TYPE=BLOCK,DEFINE=(STAT_BLOCK|STATEMENT)*",
 				"PROGRAM:TYPE=BLOCK,DEFINE=STAT_LIST#STAT_BLOCK",
@@ -153,6 +158,6 @@ public class KeyWordDefine4Java {
 			{"NEW_VIR_OBJECT","com.ql.util.express.instruction.NewVClassInstructionFactory"},
 			{"COMMENT","com.ql.util.express.instruction.NullInstructionFactory"},
 			{"EXPRESS_KEY_VALUE","com.ql.util.express.instruction.KeyValueInstructionFactory"},
-			
+			{"LAMBDA", "com.ql.util.express.instruction.LambdaInstructionFactory"}
 	};
 }

--- a/src/test/java/com/ql/util/express/test/LambdaTest.java
+++ b/src/test/java/com/ql/util/express/test/LambdaTest.java
@@ -1,0 +1,64 @@
+package com.ql.util.express.test;
+
+import com.ql.util.express.DefaultContext;
+import com.ql.util.express.ExpressRunner;
+import com.ql.util.express.Operator;
+import com.ql.util.express.QLambda;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class LambdaTest {
+
+    @Test
+    public void lambdaAddTest() throws Exception {
+        String express = "la = (a,b)->a+b; la.apply(1,2)";
+        ExpressRunner runner = new ExpressRunner(false, true);
+        DefaultContext<String, Object> context = new DefaultContext<String, Object>();
+
+        Object res = runner.execute(express, context, null, true, true);
+        Assert.assertEquals(3, res);
+    }
+
+    @Test
+    public void lambdaOperatorTest() throws Exception {
+        ExpressRunner runner = new ExpressRunner(false, true);
+        runner.addOperator("map", new Operator() {
+            @Override
+            public Object executeInner(Object[] list) throws Exception {
+                List<?> origin = (List<?>) list[0];
+                QLambda qLambda = (QLambda) list[1];
+                List result = new ArrayList();
+                for (int i = 0; i < origin.size(); i++) {
+                    result.add(qLambda.call(origin.get(i), i));
+                }
+                return result;
+            }
+        });
+
+        DefaultContext<String, Object> context = new DefaultContext<String, Object>();
+        context.put("l", Arrays.asList("a", "b", "c"));
+        Object res = runner.execute("l map (item, index)->item+index", context, null,
+                true, true);
+        Assert.assertEquals(Arrays.asList("a0", "b1", "c2"), res);
+
+        Object res1 = runner.execute("l map (item,index)->item+index", context,
+                null, true, true);
+        Assert.assertEquals(Arrays.asList("a0", "b1", "c2"), res1);
+    }
+
+    @Test
+    public void streamTest() throws Exception {
+        String expr = "a = NewList(1,2,3);a.stream().filter(item -> item > 1)" +
+                ".map(item->item+1)" +
+                ".collect(Collectors.toList())";
+        ExpressRunner runner = new ExpressRunner(false, true);
+        Object res = runner.execute(expr, new DefaultContext<String, Object>(), null,
+                false, true);
+        Assert.assertEquals(Arrays.asList(3, 4), res);
+    }
+
+}


### PR DESCRIPTION
java8 的 lambda 表达式出来这么久了，感觉 QLExpress 也应该跟进一下了，这个 pr 给出了一个实现方案，有以下特点：

 - 和 Java 的 lambda 语法完全一致，可以直接将 Java 的 lambda 表达式 copy 到 QLExpress 中运行
 - 和 Java 双向无缝交互，可以直接在脚本中写 java8 的 stream api，也可以将 lambda 作为一个参数传入到 QLExpress 中的自定义函数/Operator 中
 - 闭包，Lambda 表达式会记住自己定义时周围的环境，并从中取值

以下都是在这个 PR 中合法的 QLExpress 表达式：

```java
la = (a,b)->a+b; 
la.apply(1,2)
```

```java
a = NewList(1,2,3);
a.stream()
  .filter(item -> item > 1)
  .map(item->item+1)
  .collect(Collectors.toList())
```

另外可以将 lambda 传入自定义函数/Operator 中，只要将参数转为 `QLambda` 即可，例子如下。

假设业务上需要一个 `map` 算子，可以将左侧列表的每个元素与下标运算后生成一个新的列表，
即 `list map (item, index) -> 映射逻辑`，利用 `QLambda` 几行代码即可实现：

```java
    @Test
    public void lambdaOperatorTest() throws Exception {
        ExpressRunner runner = new ExpressRunner(false, true);
        runner.addOperator("map", new Operator() {
            @Override
            public Object executeInner(Object[] list) throws Exception {
                List<?> origin = (List<?>) list[0];
                QLambda qLambda = (QLambda) list[1];
                List result = new ArrayList();
                for (int i = 0; i < origin.size(); i++) {
                    result.add(qLambda.call(origin.get(i), i));
                }
                return result;
            }
        });

        DefaultContext<String, Object> context = new DefaultContext<String, Object>();
        context.put("l", Arrays.asList("a", "b", "c"));
        Object res = runner.execute("l map (item, index)->item+index", context, null,
                true, true);
        Assert.assertEquals(Arrays.asList("a0", "b1", "c2"), res);
    }
```

实现上所有的 Lambda 都会编译成 `QLambda` 对象，当遇到函数式接口（只有一个方法的接口）时，
会通过动态代理自动将 QLambda 适配成需要的接口。