### PR TITLE
ExpressRunner 支持线程重入

### DIFF
--- a/src/test/java/com/ql/util/express/bugfix/ExecuteReentrantTest.java
+++ b/src/test/java/com/ql/util/express/bugfix/ExecuteReentrantTest.java
@@ -1,0 +1,40 @@
+package com.ql.util.express.bugfix;
+
+import com.ql.util.express.ArraySwap;
+import com.ql.util.express.DefaultContext;
+import com.ql.util.express.ExpressRunner;
+import com.ql.util.express.InstructionSetContext;
+import com.ql.util.express.OperateData;
+import com.ql.util.express.instruction.op.OperatorBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * 线程可重入执行测试
+ */
+public class ExecuteReentrantTest {
+
+    @Test
+    public void executeReentrantTest() throws Exception {
+        String express = "eval('eval(\\'1+1\\')')";
+        ExpressRunner runner = new ExpressRunner(false, true);
+        runner.addFunction("eval", new OperatorBase() {
+            @Override
+            public OperateData executeInner(InstructionSetContext parent, ArraySwap list) throws Exception {
+                Object res = runner.execute(list.get(0).toString(), parent, null,
+                        false, true);
+                return new OperateData(res, res.getClass());
+            }
+        });
+
+        Object res = runner.execute(express, new DefaultContext<>(), null,
+                false, true);
+        Assert.assertEquals(2, res);
+
+        Object res1 = runner.execute("m = 'aaa';" +
+                        "eval('m')", new DefaultContext<>(), null,
+                false, true);
+        Assert.assertEquals("aaa", res1);
+    }
+
+}


### PR DESCRIPTION
issue #154 

修复一直以来有很多人反馈的无法线程重入执行的问题。下文中称线程第一次运行脚本为 “原执行”，在脚本中又重入运行脚本为 “重入执行”。

在线程重入的情况下，重入执行调用的 `InstructionSetRunner.executeOuter` 在返回之前会清空缓存，而且原执行使用的也是同样的缓存，这就导致原执行持有的数据都被清空了，会产生莫名其妙的错误。

![executeOuter](https://user-images.githubusercontent.com/23725000/136384542-098e6226-4896-4c86-b98e-ab3d764eeacd.png)

修复这个问题只需要判断线程重入，改成调用不清空缓存的 `InstructionSetRunner.execute` 方法即可。


