### PR TITLE
修复-变量拼写错误 maroc->macro

### DIFF
--- a/src/main/java/com/ql/util/express/InstructionSet.java
+++ b/src/main/java/com/ql/util/express/InstructionSet.java
@@ -29,7 +29,7 @@ public class InstructionSet {
     private static final transient Log log = LogFactory.getLog(InstructionSet.class);
     public static final String TYPE_CLASS = "VClass";
     public static final String TYPE_FUNCTION = "function";
-    public static final String TYPE_MARCO = "marco";
+    public static final String TYPE_MACRO = "macro";
 
     public static final boolean PRINT_INSTRUCTION_ERROR = false;
 

--- a/src/main/java/com/ql/util/express/instruction/MacroInstructionFactory.java
+++ b/src/main/java/com/ql/util/express/instruction/MacroInstructionFactory.java
@@ -17,7 +17,7 @@ public class MacroInstructionFactory extends InstructionFactory {
         for (ExpressNode tempNode : children[1].getChildrenArray()) {
             macroRoot.addChild(tempNode);
         }
-        InstructionSet macroInstructionSet = expressRunner.createInstructionSet(macroRoot, InstructionSet.TYPE_MARCO);
+        InstructionSet macroInstructionSet = expressRunner.createInstructionSet(macroRoot, InstructionSet.TYPE_MACRO);
         result.addMacroDefine(macroName, new FunctionInstructionSet(macroName, "macro", macroInstructionSet));
         return false;
     }


### PR DESCRIPTION
InstructionSet中变量拼写错了,将maroc修正为macro
