### PR TITLE
fix: add QLExpressRunStrategy all methods to risk method list

### DIFF
--- a/src/main/java/com/ql/util/express/config/QLExpressRunStrategy.java
+++ b/src/main/java/com/ql/util/express/config/QLExpressRunStrategy.java
@@ -78,11 +78,14 @@ public class QLExpressRunStrategy {
         SECURITY_RISK_METHOD_LIST.add("com.sun.rowset.JdbcRowSetImpl.setDataSourceName");
         SECURITY_RISK_METHOD_LIST.add("com.sun.rowset.JdbcRowSetImpl.setAutoCommit");
 
-        // QLE 自身开关
-        SECURITY_RISK_METHOD_LIST.add(QLExpressRunStrategy.class.getName() + ".setForbidInvokeSecurityRiskMethods");
         SECURITY_RISK_METHOD_LIST.add("jdk.jshell.JShell.create");
         SECURITY_RISK_METHOD_LIST.add("javax.script.ScriptEngineManager.getEngineByName");
         SECURITY_RISK_METHOD_LIST.add("org.springframework.jndi.JndiLocatorDelegate.lookup");
+
+        // QLE QLExpressRunStrategy的所有方法
+        for (Method method : QLExpressRunStrategy.class.getMethods()) {
+            SECURITY_RISK_METHOD_LIST.add(QLExpressRunStrategy.class.getName() + "." + method.getName());
+        }
     }
 
     private QLExpressRunStrategy() {


### PR DESCRIPTION
fix issue https://github.com/alibaba/QLExpress/issues/287

我觉得应该激进一点，将QLExpressRunStrategy的所有方法都加入黑名单，以免日后维护时新增一个危险的方法时忘记加入黑名单，导致可以注入