### PR TITLE
string support escape

### DIFF
--- a/src/main/java/com/ql/util/express/parse/WordSplit.java
+++ b/src/main/java/com/ql/util/express/parse/WordSplit.java
@@ -73,6 +73,9 @@ public class WordSplit {
                                 case 't':
                                     escapedStr.append('\t');
                                     break;
+                                case 'r':
+                                    escapedStr.append('\r');
+                                    break;
                                 default:
                                     escapedStr.append(curChar);
                             }

--- a/src/main/java/com/ql/util/express/parse/WordSplit.java
+++ b/src/main/java/com/ql/util/express/parse/WordSplit.java
@@ -13,6 +13,12 @@ import com.ql.util.express.exception.QLCompileException;
  * @author xuannan
  */
 public class WordSplit {
+    enum EscapeState {
+        CHARS,
+        MAYBE_ESCAPE,
+        END
+    }
+
     private WordSplit() {
         throw new IllegalStateException("Utility class");
     }
@@ -39,34 +45,46 @@ public class WordSplit {
             c = str.charAt(i);
             //字符串处理
             if (c == '"' || c == '\'') {
-                int index = str.indexOf(c, i + 1);
-                //处理字符串中的”问题
-                while (index > 0 && str.charAt(index - 1) == '\\') {
-                    index = str.indexOf(c, index + 1);
+                StringBuilder escapedStr = new StringBuilder().append(c);
+                EscapeState state = EscapeState.CHARS;
+                int current = i;
+
+                forward:
+                while (++current < str.length()) {
+                    char curChar = str.charAt(current);
+                    switch (state) {
+                        case CHARS:
+                            if (curChar == '\\') {
+                                state = EscapeState.MAYBE_ESCAPE;
+                                continue;
+                            }
+                            escapedStr.append(curChar);
+                            if (curChar == c) {
+                                state = EscapeState.END;
+                                break forward;
+                            }
+
+                            break;
+                        case MAYBE_ESCAPE:
+                            switch (curChar) {
+                                case 'n':
+                                    escapedStr.append('\n');
+                                    break;
+                                case 't':
+                                    escapedStr.append('\t');
+                                    break;
+                                default:
+                                    escapedStr.append(curChar);
+                            }
+                            state = EscapeState.CHARS;
+                    }
                 }
-                if (index < 0) {
+
+                if (state != EscapeState.END) {
                     throw new QLCompileException("字符串没有关闭");
                 }
-                String tempDealStr = str.substring(i, index + 1);
-                //处理 \\，\"的情况
-                StringBuilder tmpResult = new StringBuilder();
-                int tmpPoint = tempDealStr.indexOf("\\");
-                while (tmpPoint >= 0) {
-                    tmpResult.append(tempDealStr, 0, tmpPoint);
-                    if (tmpPoint == tempDealStr.length() - 1) {
-                        throw new QLCompileException("字符串中的" + "\\错误:" + tempDealStr);
-                    }
-                    tmpResult.append(tempDealStr.charAt(tmpPoint + 1));
-                    tempDealStr = tempDealStr.substring(tmpPoint + 2);
-                    tmpPoint = tempDealStr.indexOf("\\");
-                }
-                tmpResult.append(tempDealStr);
-                list.add(new Word(tmpResult.toString(), line, i - currentLineOffset + 1));
-
-                if (point < i) {
-                    list.add(new Word(str.substring(point, i), line, point - currentLineOffset + 1));
-                }
-                i = index + 1;
+                list.add(new Word(escapedStr.toString(), line, i - currentLineOffset + 1));
+                i = current + 1;
                 point = i;
             } else if (c == '.' && point < i && isNumber(str.substring(point, i))) {
                 //小数点的特殊处理

--- a/src/test/java/com/ql/util/express/bugfix/StringTest.java
+++ b/src/test/java/com/ql/util/express/bugfix/StringTest.java
@@ -5,6 +5,8 @@ import com.ql.util.express.ExpressRunner;
 import com.ql.util.express.IExpressContext;
 import org.junit.Test;
 
+import static org.junit.Assert.*;
+
 /**
  * Created by tianqiao on 17/7/5.
  */
@@ -17,5 +19,22 @@ public class StringTest {
         IExpressContext<String, Object> context = new DefaultContext<>();
         Object result = runner.execute(exp, context, null, false, false);
         System.out.println(result);
+    }
+
+    @Test
+    public void stringEscapeTest() throws Exception {
+        ExpressRunner runner = new ExpressRunner(false, true);
+        IExpressContext<String, Object> context = new DefaultContext<>();
+
+        assertEquals("\"aaa\"", runner.execute("\"\\\"aaa\\\"\"", context, null, false, false));
+        assertEquals("aaa'aa", runner.execute("'aaa\\'aa'", context, null, false, false));
+        assertEquals("aaa\\aa", runner.execute("'aaa\\\\aa'", context, null, false, false));
+
+        // 不认识的转义符 \a, 默认忽略掉 \
+        assertEquals("aaaaa", runner.execute("'aaa\\aa'", context, null, false, false));
+        assertEquals("", runner.execute("''", context, null, false, false));
+        assertEquals("\n\t", runner.execute("'\\n\\t'", context, null, false, false));
+        assertEquals("\n\tm", runner.execute("'\\n\\t\\m'", context, null, false, false));
+        assertEquals("", runner.execute("\"\"", context, null, false, false));
     }
 }

--- a/src/test/java/com/ql/util/express/bugfix/StringTest.java
+++ b/src/test/java/com/ql/util/express/bugfix/StringTest.java
@@ -15,10 +15,9 @@ public class StringTest {
     public void testFunction() throws Exception {
         ExpressRunner runner = new ExpressRunner();
         String exp = "a = \"11111,2222\";p = a.split(\",\");";
-        System.out.println(exp);
         IExpressContext<String, Object> context = new DefaultContext<>();
         Object result = runner.execute(exp, context, null, false, false);
-        System.out.println(result);
+        assertArrayEquals(new String[] {"11111", "2222"}, (String[]) result);
     }
 
     @Test
@@ -33,8 +32,8 @@ public class StringTest {
         // 不认识的转义符 \a, 默认忽略掉 \
         assertEquals("aaaaa", runner.execute("'aaa\\aa'", context, null, false, false));
         assertEquals("", runner.execute("''", context, null, false, false));
-        assertEquals("\n\t", runner.execute("'\\n\\t'", context, null, false, false));
-        assertEquals("\n\tm", runner.execute("'\\n\\t\\m'", context, null, false, false));
+        assertEquals("\n\t\r", runner.execute("'\\n\\t\\r'", context, null, false, false));
+        assertEquals("\n\tm\r", runner.execute("'\\n\\t\\m\\r'", context, null, false, false));
         assertEquals("", runner.execute("\"\"", context, null, false, false));
     }
 }


### PR DESCRIPTION
现状: QLExpress 不支持转义字符, 所有的转义字符会被去除斜杠,比如 "\n" 在运行时会变成 n

新规则:
 - 支持常见转义字符 \n \t
 - 不支持的转义字符和之前兼容, 比如 \a 会被解析成 a