### PR TITLE
将指令集缓存设置成静态变量

### DIFF
--- a/src/main/java/com/ql/util/express/ExpressRunner.java
+++ b/src/main/java/com/ql/util/express/ExpressRunner.java
@@ -61,7 +61,7 @@ public class ExpressRunner {
      * 一段文本对应的指令集的缓存
      * default: ConcurrentHashMap with no eviction policy
      */
-    private final Map<String, Future<InstructionSet>> expressInstructionSetCache;
+    private static final Map<String, Future<InstructionSet>> expressInstructionSetCache = new ConcurrentHashMap<>();;
 
     private final ExpressLoader loader;
 
@@ -165,10 +165,8 @@ public class ExpressRunner {
             manager = nodeTypeManager;
         }
 
-        if (Objects.isNull(cacheMap)) {
-            expressInstructionSetCache = new ConcurrentHashMap<>();
-        } else {
-            expressInstructionSetCache = cacheMap;
+        if (!Objects.isNull(cacheMap)) {
+            expressInstructionSetCache.putAll(cacheMap);
         }
         this.operatorManager = new OperatorFactory(this.isPrecise);
         this.loader = new ExpressLoader(this);


### PR DESCRIPTION
对`ExpressRunner`进行初始化时，如果没有使用单例，有可能会导致成员变量`expressInstructionSetCache`每次都不会命中，每次都需要进行重新生成指令集，效率很低。
`ExpressRunner expressRunner = new ExpressRunner();`
将指令集缓存设置成静态变量可以解决这个问题。