### PR TITLE
Support adding operator of type `BinaryOperator`

### DIFF
--- a/src/main/java/com/alibaba/qlexpress4/Express4Runner.java
+++ b/src/main/java/com/alibaba/qlexpress4/Express4Runner.java
@@ -34,6 +34,7 @@ import com.alibaba.qlexpress4.runtime.function.CustomFunction;
 import com.alibaba.qlexpress4.runtime.function.ExtensionFunction;
 import com.alibaba.qlexpress4.runtime.function.QMethodFunction;
 import com.alibaba.qlexpress4.runtime.instruction.QLInstruction;
+import com.alibaba.qlexpress4.runtime.operator.BinaryOperator;
 import com.alibaba.qlexpress4.runtime.operator.CustomBinaryOperator;
 import com.alibaba.qlexpress4.runtime.operator.OperatorManager;
 import com.alibaba.qlexpress4.runtime.trace.ExpressionTrace;
@@ -715,6 +716,15 @@ public class Express4Runner {
      */
     public boolean addOperator(String operator, CustomBinaryOperator customBinaryOperator, int precedence) {
         return operatorManager.addBinaryOperator(operator, customBinaryOperator, precedence);
+    }
+    
+    /**
+     * add operator
+     * @param operator operator to add
+     * @return true if add operator successfully; false if operator already exist
+     */
+    public boolean addOperator(BinaryOperator operator) {
+        return operatorManager.addBinaryOperator(operator);
     }
     
     /**

--- a/src/main/java/com/alibaba/qlexpress4/runtime/operator/OperatorManager.java
+++ b/src/main/java/com/alibaba/qlexpress4/runtime/operator/OperatorManager.java
@@ -169,11 +169,21 @@ public class OperatorManager implements OperatorFactory, ParserOperatorManager {
      * @return {@code true} if registered successfully; {@code false} if the name is already used
      */
     public boolean addBinaryOperator(String operatorName, CustomBinaryOperator customBinaryOperator, int priority) {
-        if (DEFAULT_BINARY_OPERATOR_MAP.containsKey(operatorName)) {
+        return addBinaryOperator(adapt2BinOp(operatorName, customBinaryOperator, priority));
+    }
+    
+    /**
+     * Register a custom binary operator if it does not clash with a built-in operator.
+     *
+     * @param binaryOperator        operator to add
+     * @return {@code true} if registered successfully; {@code false} if the name is already used
+     */
+    public boolean addBinaryOperator(BinaryOperator binaryOperator) {
+        String operator = binaryOperator.getOperator();
+        if (DEFAULT_BINARY_OPERATOR_MAP.containsKey(operator)) {
             return false;
         }
-        BinaryOperator preBinaryOperator = customBinaryOperatorMap.putIfAbsent(operatorName,
-            adapt2BinOp(operatorName, customBinaryOperator, priority));
+        BinaryOperator preBinaryOperator = customBinaryOperatorMap.putIfAbsent(operator, binaryOperator);
         return preBinaryOperator == null;
     }
     

--- a/src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java
+++ b/src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java
@@ -5,17 +5,20 @@ import com.alibaba.qlexpress4.annotation.QLFunction;
 import com.alibaba.qlexpress4.aparser.ImportManager;
 import com.alibaba.qlexpress4.aparser.InterpolationMode;
 import com.alibaba.qlexpress4.api.BatchAddFunctionResult;
+import com.alibaba.qlexpress4.exception.ErrorReporter;
 import com.alibaba.qlexpress4.exception.QLErrorCodes;
 import com.alibaba.qlexpress4.exception.QLException;
 import com.alibaba.qlexpress4.exception.QLRuntimeException;
 import com.alibaba.qlexpress4.exception.QLSyntaxException;
 import com.alibaba.qlexpress4.exception.QLTimeoutException;
 import com.alibaba.qlexpress4.inport.MyDesk;
+import com.alibaba.qlexpress4.runtime.QRuntime;
 import com.alibaba.qlexpress4.runtime.Value;
 import com.alibaba.qlexpress4.runtime.context.DynamicVariableContext;
 import com.alibaba.qlexpress4.runtime.context.ExpressContext;
 import com.alibaba.qlexpress4.runtime.data.DataValue;
 import com.alibaba.qlexpress4.runtime.function.ExtensionFunction;
+import com.alibaba.qlexpress4.runtime.operator.base.BaseBinaryOperator;
 import com.alibaba.qlexpress4.runtime.trace.ExpressionTrace;
 import com.alibaba.qlexpress4.runtime.trace.TracePointTree;
 import com.alibaba.qlexpress4.security.QLSecurityStrategy;
@@ -1322,6 +1325,21 @@ public class Express4RunnerTest {
             assertEquals("INVALID_ARGUMENT", e.getErrorCode());
             assertEquals("custom e test", e.getReason());
         }
+        express4Runner.addOperator(new NonNullEqual());
+        Object result5 =
+            express4Runner.execute("null === null", new HashMap<>(), QLOptions.DEFAULT_OPTIONS).getResult();
+        assertEquals(Boolean.FALSE, result5);
+        Map<String, Object> ctx = new HashMap<>();
+        ctx.put("x", null);
+        ctx.put("y", 100);
+        ctx.put("z", "a100");
+        Object result6 = express4Runner.execute("x === null", ctx, QLOptions.DEFAULT_OPTIONS).getResult();
+        assertEquals(Boolean.FALSE, result6);
+        Object result7 =
+            express4Runner.execute("1+2===3 && 'a' join y===z", ctx, QLOptions.builder().cache(false).build())
+                .getResult();
+        assertEquals(Boolean.TRUE, result7);
+        
     }
     
     @Test
@@ -1838,5 +1856,27 @@ public class Express4RunnerTest {
         QLResult result = express4Runner
             .execute("default = 1\nswitch = 2;\ndefault+switch", Collections.emptyMap(), QLOptions.DEFAULT_OPTIONS);
         assertEquals(3, result.getResult());
+    }
+    
+    static class NonNullEqual extends BaseBinaryOperator {
+        
+        @Override
+        public Object execute(Value left, Value right, QRuntime qRuntime, QLOptions qlOptions,
+            ErrorReporter errorReporter) {
+            if (left.get() == null || right.get() == null) {
+                return false;
+            }
+            return equals(left, right, errorReporter);
+        }
+        
+        @Override
+        public String getOperator() {
+            return "===";
+        }
+        
+        @Override
+        public int getPriority() {
+            return QLPrecedences.COMPARE;
+        }
     }
 }


### PR DESCRIPTION
`Express4Runner`增加`addOperator`方法重载，参数类型为`BinaryOperator`，用户可以通过继承`BaseBinaryOperator`访问该类中的辅助方法，方便实现一些操作符的变体