### PR TITLE
Add pluggable expression cache interface with LRU and TTL support

### DIFF
--- a/README-EN-source.adoc
+++ b/README-EN-source.adoc
@@ -364,14 +364,94 @@ Typical application scenarios for custom ClassSupplier:
 
 Through the `cache` option, you can enable expression caching, so the same expressions won't be recompiled, greatly improving performance.
 
-Note that this cache has no size limit and is only suitable for use when expressions are in limited quantities:
+==== Basic Cache Usage
+
+The basic cache has no size limit and is only suitable for use when expressions are in limited quantities:
 
 [source,java,indent=0]
 ----
 include::./src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java[tag=cacheSwitch]
 ----
 
-However, when scripts are executed for the first time, they're still relatively slow because there's no cache.
+==== Advanced Cache Configuration
+
+QLExpress4 provides configurable cache implementations supporting the following features:
+
+* **LRU Eviction**: Automatically evicts least recently used entries when cache reaches maximum capacity
+* **TTL Expiration**: Supports setting expiration time for cache entries
+* **Custom Implementation**: Can provide custom cache implementation through interface
+
+===== LRU Cache (Limit Maximum Entries)
+
+[source,java,indent=0]
+----
+// Create an LRU cache with max capacity of 100
+CacheConfig config = CacheConfig.lruConfig(100);
+InitOptions initOptions = InitOptions.builder()
+    .cacheConfig(config)
+    .build();
+Express4Runner runner = new Express4Runner(initOptions);
+----
+
+When the cache reaches maximum capacity, the least recently used entries are automatically evicted.
+
+===== TTL Cache (Set Expiration Time)
+
+[source,java,indent=0]
+----
+// Create a cache with 5 minutes TTL
+CacheConfig config = CacheConfig.ttlConfig(TimeUnit.MINUTES.toMillis(5));
+InitOptions initOptions = InitOptions.builder()
+    .cacheConfig(config)
+    .build();
+Express4Runner runner = new Express4Runner(initOptions);
+----
+
+Expired cache entries are automatically cleaned up on access, with a background thread for periodic cleanup.
+
+===== LRU + TTL Combined Cache
+
+[source,java,indent=0]
+----
+// Create a cache with max capacity of 100 and 5 minutes TTL
+CacheConfig config = CacheConfig.lruAndTtlConfig(100, TimeUnit.MINUTES.toMillis(5));
+InitOptions initOptions = InitOptions.builder()
+    .cacheConfig(config)
+    .build();
+Express4Runner runner = new Express4Runner(initOptions);
+----
+
+Or use Builder for more fine-grained configuration:
+
+[source,java,indent=0]
+----
+CacheConfig config = CacheConfig.builder()
+    .maxSize(100)
+    .ttl(5, TimeUnit.MINUTES)
+    .lruEnabled(true)
+    .initialCapacity(16)
+    .build();
+----
+
+===== Custom Cache Implementation
+
+If the built-in cache implementations don't meet your needs, you can provide a custom implementation through the `ExpressionCache` interface:
+
+[source,java,indent=0]
+----
+ExpressionCache customCache = new ExpressionCache() {
+    // Implement cache methods
+};
+
+InitOptions initOptions = InitOptions.builder()
+    .expressionCache(customCache)
+    .build();
+Express4Runner runner = new Express4Runner(initOptions);
+----
+
+==== Pre-caching Scripts
+
+When scripts are executed for the first time, they're relatively slow because there's no cache.
 
 You can cache scripts before first execution using the following method to ensure first execution speed:
 
@@ -380,7 +460,18 @@ You can cache scripts before first execution using the following method to ensur
 include::./src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java[tag=parseToCache]
 ----
 
-Note that this cache has an unlimited size; be sure to control its size in your application. You can periodically clear the compilation cache by calling the `clearCompileCache` method.
+==== Clearing Cache
+
+You can manage the cache using the following methods:
+
+[source,java,indent=0]
+----
+// Clear all cache
+runner.clearCompileCache();
+
+// Get current cache size
+int size = runner.getCompileCacheSize();
+----
 
 === Clearing DFA Cache
 

--- a/README-source.adoc
+++ b/README-source.adoc
@@ -365,14 +365,96 @@ include::./src/test/java/com/alibaba/qlexpress4/pf4j/Pf4jClassSupplierTest.java[
 
 通过 `cache` 选项可以开启表达式缓存，这样相同的表达式就不会重新编译，能够大大提升性能。
 
-注意该缓存没有限制大小，只适合在表达式为有限数量的情况下使用：
+==== 基础缓存使用
+
+基础缓存没有限制大小，只适合在表达式为有限数量的情况下使用：
 
 [source,java,indent=0]
 ----
 include::./src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java[tag=cacheSwitch]
 ----
 
-但是当脚本首次执行时，因为没有缓存，依旧会比较慢。
+注意该缓存没有限制大小，只适合在表达式为有限数量的情况下使用。
+
+==== 高级缓存配置
+
+QLExpress4 提供了可配置的缓存实现，支持以下特性：
+
+* **LRU 淘汰**：当缓存达到最大容量时，自动淘汰最近最少使用的条目
+* **TTL 过期**：支持设置缓存条目的过期时间
+* **自定义实现**：可以通过接口提供自定义缓存实现
+
+===== LRU 缓存（限制最大条目数）
+
+[source,java,indent=0]
+----
+// 创建最大容量为 100 的 LRU 缓存
+CacheConfig config = CacheConfig.lruConfig(100);
+InitOptions initOptions = InitOptions.builder()
+    .cacheConfig(config)
+    .build();
+Express4Runner runner = new Express4Runner(initOptions);
+----
+
+当缓存达到最大容量时，最近最少使用的条目会被自动淘汰。
+
+===== TTL 缓存（设置过期时间）
+
+[source,java,indent=0]
+----
+// 创建 5 分钟 TTL 的缓存
+CacheConfig config = CacheConfig.ttlConfig(TimeUnit.MINUTES.toMillis(5));
+InitOptions initOptions = InitOptions.builder()
+    .cacheConfig(config)
+    .build();
+Express4Runner runner = new Express4Runner(initOptions);
+----
+
+过期的缓存条目会在访问时自动清理，并有后台线程定期清理。
+
+===== LRU + TTL 组合缓存
+
+[source,java,indent=0]
+----
+// 创建最大容量为 100、TTL 为 5 分钟的缓存
+CacheConfig config = CacheConfig.lruAndTtlConfig(100, TimeUnit.MINUTES.toMillis(5));
+InitOptions initOptions = InitOptions.builder()
+    .cacheConfig(config)
+    .build();
+Express4Runner runner = new Express4Runner(initOptions);
+----
+
+也可以通过 Builder 进行更精细的配置：
+
+[source,java,indent=0]
+----
+CacheConfig config = CacheConfig.builder()
+    .maxSize(100)
+    .ttl(5, TimeUnit.MINUTES)
+    .lruEnabled(true)
+    .initialCapacity(16)
+    .build();
+----
+
+===== 自定义缓存实现
+
+如果内置缓存实现不满足需求，可以通过 `ExpressionCache` 接口提供自定义实现：
+
+[source,java,indent=0]
+----
+ExpressionCache customCache = new ExpressionCache() {
+    // 实现缓存方法
+};
+
+InitOptions initOptions = InitOptions.builder()
+    .expressionCache(customCache)
+    .build();
+Express4Runner runner = new Express4Runner(initOptions);
+----
+
+==== 预缓存脚本
+
+当脚本首次执行时，因为没有缓存，会比较慢。
 
 可以通过下面的方法在首次执行前就将脚本缓存起来，保证首次执行的速度：
 
@@ -381,7 +463,18 @@ include::./src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java[tag=cach
 include::./src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java[tag=parseToCache]
 ----
 
-注意该缓存的大小是无限的，业务上注意控制大小，可以调用 `clearCompileCache` 方法定期清空编译缓存。
+==== 清理缓存
+
+可以调用以下方法管理缓存：
+
+[source,java,indent=0]
+----
+// 清空所有缓存
+runner.clearCompileCache();
+
+// 获取当前缓存大小
+int size = runner.getCompileCacheSize();
+----
 
 === 清除 DFA 缓存
 

--- a/src/main/java/com/alibaba/qlexpress4/Express4Runner.java
+++ b/src/main/java/com/alibaba/qlexpress4/Express4Runner.java
@@ -15,6 +15,10 @@ import com.alibaba.qlexpress4.aparser.TraceExpressionVisitor;
 import com.alibaba.qlexpress4.aparser.compiletimefunction.CompileTimeFunction;
 import com.alibaba.qlexpress4.api.BatchAddFunctionResult;
 import com.alibaba.qlexpress4.api.QLFunctionalVarargs;
+import com.alibaba.qlexpress4.cache.CacheConfig;
+import com.alibaba.qlexpress4.cache.DefaultExpressionCache;
+import com.alibaba.qlexpress4.cache.ExpressionCache;
+import com.alibaba.qlexpress4.cache.SimpleExpressionCache;
 import com.alibaba.qlexpress4.exception.PureErrReporter;
 import com.alibaba.qlexpress4.exception.QLException;
 import com.alibaba.qlexpress4.exception.QLSyntaxException;
@@ -65,22 +69,39 @@ import java.util.stream.Collectors;
  */
 public class Express4Runner {
     private final OperatorManager operatorManager = new OperatorManager();
-    
-    private final Map<String, Future<QCompileCache>> compileCache = new ConcurrentHashMap<>();
-    
+
+    private final ExpressionCache compileCache;
+
     private final Map<String, CustomFunction> userDefineFunction = new ConcurrentHashMap<>();
-    
+
     private final Map<String, CompileTimeFunction> compileTimeFunctions = new ConcurrentHashMap<>();
-    
+
     private final GeneratorScope globalScope = new GeneratorScope(null, "global", new ConcurrentHashMap<>());
-    
+
     private final ReflectLoader reflectLoader;
-    
+
     private final InitOptions initOptions;
-    
+
     public Express4Runner(InitOptions initOptions) {
         this.initOptions = initOptions;
         this.reflectLoader = new ReflectLoader(initOptions.getSecurityStrategy(), initOptions.isAllowPrivateAccess());
+        this.compileCache = initCache(initOptions);
+    }
+
+    private ExpressionCache initCache(InitOptions options) {
+        // If custom cache is provided, use it
+        if (options.getExpressionCache() != null) {
+            return options.getExpressionCache();
+        }
+
+        // If cache config is provided, use DefaultExpressionCache with config
+        CacheConfig config = options.getCacheConfig();
+        if (config != null) {
+            return new DefaultExpressionCache(config);
+        }
+
+        // Default: use SimpleExpressionCache (unlimited, thread-safe)
+        return new SimpleExpressionCache();
     }
     
     public CustomFunction getFunction(String functionName) {
@@ -648,7 +669,15 @@ public class Express4Runner {
     public void clearCompileCache() {
         compileCache.clear();
     }
-    
+
+    /**
+     * Get the current compile cache size.
+     * @return number of cached entries
+     */
+    public int getCompileCacheSize() {
+        return compileCache.size();
+    }
+
     private Future<QCompileCache> getParseFuture(String script) {
         Future<QCompileCache> parseFuture = compileCache.get(script);
         if (parseFuture != null) {

--- a/src/main/java/com/alibaba/qlexpress4/InitOptions.java
+++ b/src/main/java/com/alibaba/qlexpress4/InitOptions.java
@@ -2,6 +2,8 @@ package com.alibaba.qlexpress4;
 
 import com.alibaba.qlexpress4.aparser.ImportManager;
 import com.alibaba.qlexpress4.aparser.InterpolationMode;
+import com.alibaba.qlexpress4.cache.CacheConfig;
+import com.alibaba.qlexpress4.cache.ExpressionCache;
 import com.alibaba.qlexpress4.security.QLSecurityStrategy;
 
 import java.util.ArrayList;
@@ -83,10 +85,24 @@ public class InitOptions {
      */
     private final boolean strictNewLines;
     
+    /**
+     * Expression cache configuration.
+     * If null, uses default unlimited cache.
+     * default null
+     */
+    private final CacheConfig cacheConfig;
+
+    /**
+     * Custom expression cache implementation.
+     * If null, uses DefaultExpressionCache with cacheConfig.
+     * default null
+     */
+    private final ExpressionCache expressionCache;
+
     private InitOptions(ClassSupplier classSupplier, List<ImportManager.QLImport> defaultImport, boolean debug,
         Consumer<String> debugInfoConsumer, QLSecurityStrategy securityStrategy, boolean allowPrivateAccess,
         InterpolationMode interpolationMode, boolean traceExpression, String selectorStart, String selectorEnd,
-        boolean strictNewLines) {
+        boolean strictNewLines, CacheConfig cacheConfig, ExpressionCache expressionCache) {
         this.classSupplier = classSupplier;
         this.defaultImport = defaultImport;
         this.debug = debug;
@@ -98,6 +114,8 @@ public class InitOptions {
         this.selectorStart = selectorStart;
         this.selectorEnd = selectorEnd;
         this.strictNewLines = strictNewLines;
+        this.cacheConfig = cacheConfig;
+        this.expressionCache = expressionCache;
     }
     
     public static InitOptions.Builder builder() {
@@ -147,7 +165,15 @@ public class InitOptions {
     public boolean isStrictNewLines() {
         return strictNewLines;
     }
-    
+
+    public CacheConfig getCacheConfig() {
+        return cacheConfig;
+    }
+
+    public ExpressionCache getExpressionCache() {
+        return expressionCache;
+    }
+
     public static class Builder {
         private ClassSupplier classSupplier = DefaultClassSupplier.getInstance();
         
@@ -175,7 +201,11 @@ public class InitOptions {
         private String selectorEnd = "}";
         
         private boolean strictNewLines = true;
-        
+
+        private CacheConfig cacheConfig = null;
+
+        private ExpressionCache expressionCache = null;
+
         public Builder classSupplier(ClassSupplier classSupplier) {
             this.classSupplier = classSupplier;
             return this;
@@ -236,10 +266,21 @@ public class InitOptions {
             this.strictNewLines = strictNewLines;
             return this;
         }
-        
+
+        public Builder cacheConfig(CacheConfig cacheConfig) {
+            this.cacheConfig = cacheConfig;
+            return this;
+        }
+
+        public Builder expressionCache(ExpressionCache expressionCache) {
+            this.expressionCache = expressionCache;
+            return this;
+        }
+
         public InitOptions build() {
             return new InitOptions(classSupplier, defaultImport, debug, debugInfoConsumer, securityStrategy,
-                allowPrivateAccess, interpolationMode, traceExpression, selectorStart, selectorEnd, strictNewLines);
+                allowPrivateAccess, interpolationMode, traceExpression, selectorStart, selectorEnd, strictNewLines,
+                cacheConfig, expressionCache);
         }
     }
 }

--- a/src/main/java/com/alibaba/qlexpress4/cache/CacheConfig.java
+++ b/src/main/java/com/alibaba/qlexpress4/cache/CacheConfig.java
@@ -1,0 +1,148 @@
+package com.alibaba.qlexpress4.cache;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Configuration for expression cache.
+ * Used to customize cache behavior in DefaultExpressionCache.
+ *
+ * @author QLExpress Team
+ */
+public class CacheConfig {
+
+    /**
+     * Default maximum cache size (unlimited: -1)
+     */
+    public static final int DEFAULT_MAX_SIZE = -1;
+
+    /**
+     * Default TTL in milliseconds (no expiration: -1)
+     */
+    public static final long DEFAULT_TTL_MILLIS = -1;
+
+    /**
+     * Default initial capacity
+     */
+    public static final int DEFAULT_INITIAL_CAPACITY = 16;
+
+    /**
+     * Maximum number of cached entries.
+     * -1 means unlimited.
+     */
+    private final int maxSize;
+
+    /**
+     * Time to live in milliseconds.
+     * -1 means no expiration.
+     */
+    private final long ttlMillis;
+
+    /**
+     * Initial capacity of the cache.
+     */
+    private final int initialCapacity;
+
+    /**
+     * Whether to enable LRU eviction when maxSize is reached.
+     */
+    private final boolean lruEnabled;
+
+    private CacheConfig(int maxSize, long ttlMillis, int initialCapacity, boolean lruEnabled) {
+        this.maxSize = maxSize;
+        this.ttlMillis = ttlMillis;
+        this.initialCapacity = initialCapacity;
+        this.lruEnabled = lruEnabled;
+    }
+
+    public int getMaxSize() {
+        return maxSize;
+    }
+
+    public long getTtlMillis() {
+        return ttlMillis;
+    }
+
+    public int getInitialCapacity() {
+        return initialCapacity;
+    }
+
+    public boolean isLruEnabled() {
+        return lruEnabled;
+    }
+
+    public boolean isMaxSizeEnabled() {
+        return maxSize > 0;
+    }
+
+    public boolean isTtlEnabled() {
+        return ttlMillis > 0;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Create a default unlimited cache configuration.
+     */
+    public static CacheConfig defaultConfig() {
+        return new CacheConfig(DEFAULT_MAX_SIZE, DEFAULT_TTL_MILLIS, DEFAULT_INITIAL_CAPACITY, false);
+    }
+
+    /**
+     * Create an LRU cache configuration with specified max size.
+     */
+    public static CacheConfig lruConfig(int maxSize) {
+        return new CacheConfig(maxSize, DEFAULT_TTL_MILLIS, DEFAULT_INITIAL_CAPACITY, true);
+    }
+
+    /**
+     * Create a TTL cache configuration with specified time to live.
+     */
+    public static CacheConfig ttlConfig(long ttlMillis) {
+        return new CacheConfig(DEFAULT_MAX_SIZE, ttlMillis, DEFAULT_INITIAL_CAPACITY, false);
+    }
+
+    /**
+     * Create a cache configuration with both LRU and TTL.
+     */
+    public static CacheConfig lruAndTtlConfig(int maxSize, long ttlMillis) {
+        return new CacheConfig(maxSize, ttlMillis, DEFAULT_INITIAL_CAPACITY, true);
+    }
+
+    public static class Builder {
+        private int maxSize = DEFAULT_MAX_SIZE;
+        private long ttlMillis = DEFAULT_TTL_MILLIS;
+        private int initialCapacity = DEFAULT_INITIAL_CAPACITY;
+        private boolean lruEnabled = false;
+
+        public Builder maxSize(int maxSize) {
+            this.maxSize = maxSize;
+            return this;
+        }
+
+        public Builder ttlMillis(long ttlMillis) {
+            this.ttlMillis = ttlMillis;
+            return this;
+        }
+
+        public Builder ttl(long duration, TimeUnit unit) {
+            this.ttlMillis = unit.toMillis(duration);
+            return this;
+        }
+
+        public Builder initialCapacity(int initialCapacity) {
+            this.initialCapacity = initialCapacity;
+            return this;
+        }
+
+        public Builder lruEnabled(boolean lruEnabled) {
+            this.lruEnabled = lruEnabled;
+            return this;
+        }
+
+        public CacheConfig build() {
+            return new CacheConfig(maxSize, ttlMillis, initialCapacity, lruEnabled);
+        }
+    }
+}

--- a/src/main/java/com/alibaba/qlexpress4/cache/DefaultExpressionCache.java
+++ b/src/main/java/com/alibaba/qlexpress4/cache/DefaultExpressionCache.java
@@ -1,0 +1,249 @@
+package com.alibaba.qlexpress4.cache;
+
+import com.alibaba.qlexpress4.aparser.QCompileCache;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Default expression cache implementation with advanced features.
+ * Supports:
+ * - Maximum size limit with LRU eviction
+ * - Time-to-live (TTL) expiration
+ * - Thread-safe operations
+ * <p>
+ * When both maxSize and TTL are configured, entries may be evicted
+ * based on either condition.
+ *
+ * @author QLExpress Team
+ */
+public class DefaultExpressionCache implements ExpressionCache {
+
+    private final CacheConfig config;
+    private final ConcurrentHashMap<String, CacheEntry> cache;
+    private final ScheduledExecutorService cleanupExecutor;
+    private final AtomicLong accessCounter;
+
+    /**
+     * Cache entry wrapper that tracks metadata for eviction.
+     */
+    private static class CacheEntry {
+        final Future<QCompileCache> future;
+        final long createTime;
+        volatile long lastAccessTime;
+        volatile long accessOrder;
+
+        CacheEntry(Future<QCompileCache> future, long createTime) {
+            this.future = future;
+            this.createTime = createTime;
+            this.lastAccessTime = createTime;
+            this.accessOrder = 0;
+        }
+    }
+
+    /**
+     * Create a default cache with unlimited size and no expiration.
+     */
+    public DefaultExpressionCache() {
+        this(CacheConfig.defaultConfig());
+    }
+
+    /**
+     * Create a cache with specified configuration.
+     *
+     * @param config cache configuration
+     */
+    public DefaultExpressionCache(CacheConfig config) {
+        this.config = config != null ? config : CacheConfig.defaultConfig();
+        this.cache = new ConcurrentHashMap<>(this.config.getInitialCapacity());
+        this.accessCounter = new AtomicLong(0);
+
+        // Setup TTL cleanup if enabled
+        if (this.config.isTtlEnabled()) {
+            this.cleanupExecutor = new ScheduledThreadPoolExecutor(1, r -> {
+                Thread t = new Thread(r, "qlexpress-cache-cleanup");
+                t.setDaemon(true);
+                return t;
+            });
+            // Schedule periodic cleanup every TTL/2 or at least every minute
+            long cleanupInterval = Math.min(this.config.getTtlMillis() / 2, 60000);
+            cleanupInterval = Math.max(cleanupInterval, 1000); // At least 1 second
+            this.cleanupExecutor.scheduleWithFixedDelay(
+                this::cleanupExpiredEntries,
+                cleanupInterval,
+                cleanupInterval,
+                TimeUnit.MILLISECONDS
+            );
+        } else {
+            this.cleanupExecutor = null;
+        }
+    }
+
+    @Override
+    public Future<QCompileCache> get(String script) {
+        CacheEntry entry = cache.get(script);
+        if (entry == null) {
+            return null;
+        }
+
+        // Check TTL expiration
+        if (config.isTtlEnabled() && isExpired(entry)) {
+            cache.remove(script, entry);
+            return null;
+        }
+
+        // Update access metadata
+        entry.lastAccessTime = System.currentTimeMillis();
+        entry.accessOrder = accessCounter.incrementAndGet();
+
+        return entry.future;
+    }
+
+    @Override
+    public Future<QCompileCache> put(String script, Future<QCompileCache> future) {
+        // Check if we need to evict before adding
+        if (config.isMaxSizeEnabled() && cache.size() >= config.getMaxSize()) {
+            evictEntry();
+        }
+
+        CacheEntry newEntry = new CacheEntry(future, System.currentTimeMillis());
+        newEntry.accessOrder = accessCounter.incrementAndGet();
+
+        CacheEntry oldEntry = cache.put(script, newEntry);
+        return oldEntry != null ? oldEntry.future : null;
+    }
+
+    @Override
+    public Future<QCompileCache> putIfAbsent(String script, Future<QCompileCache> future) {
+        CacheEntry existing = cache.get(script);
+        if (existing != null) {
+            // Check if existing entry is expired
+            if (config.isTtlEnabled() && isExpired(existing)) {
+                if (cache.remove(script, existing)) {
+                    // Entry was expired and removed, continue to add new one
+                } else {
+                    // Someone else removed and added, get the new one
+                    CacheEntry newExisting = cache.get(script);
+                    return newExisting != null ? newExisting.future : null;
+                }
+            } else {
+                return existing.future;
+            }
+        }
+
+        // Check if we need to evict before adding
+        if (config.isMaxSizeEnabled() && cache.size() >= config.getMaxSize()) {
+            evictEntry();
+        }
+
+        CacheEntry newEntry = new CacheEntry(future, System.currentTimeMillis());
+        newEntry.accessOrder = accessCounter.incrementAndGet();
+
+        CacheEntry previous = cache.putIfAbsent(script, newEntry);
+        return previous != null ? previous.future : null;
+    }
+
+    @Override
+    public Future<QCompileCache> remove(String script) {
+        CacheEntry entry = cache.remove(script);
+        return entry != null ? entry.future : null;
+    }
+
+    @Override
+    public void clear() {
+        cache.clear();
+    }
+
+    @Override
+    public int size() {
+        if (config.isTtlEnabled()) {
+            // Clean up expired entries before returning size for accuracy
+            cleanupExpiredEntries();
+        }
+        return cache.size();
+    }
+
+    @Override
+    public boolean contains(String script) {
+        CacheEntry entry = cache.get(script);
+        if (entry == null) {
+            return false;
+        }
+
+        // Check TTL expiration
+        if (config.isTtlEnabled() && isExpired(entry)) {
+            cache.remove(script, entry);
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Shutdown the cache and cleanup resources.
+     * Should be called when the Express4Runner is no longer needed.
+     */
+    public void shutdown() {
+        if (cleanupExecutor != null) {
+            cleanupExecutor.shutdown();
+        }
+        clear();
+    }
+
+    /**
+     * Check if an entry has expired based on TTL.
+     */
+    private boolean isExpired(CacheEntry entry) {
+        return System.currentTimeMillis() - entry.createTime > config.getTtlMillis();
+    }
+
+    /**
+     * Remove expired entries from cache.
+     */
+    private void cleanupExpiredEntries() {
+        if (!config.isTtlEnabled()) {
+            return;
+        }
+
+        long now = System.currentTimeMillis();
+        cache.entrySet().removeIf(entry -> {
+            CacheEntry ce = entry.getValue();
+            return now - ce.createTime > config.getTtlMillis();
+        });
+    }
+
+    /**
+     * Evict an entry based on LRU policy.
+     * Finds and removes the least recently accessed entry.
+     */
+    private void evictEntry() {
+        if (!config.isLruEnabled() || cache.isEmpty()) {
+            // If LRU is not enabled but we need to make space,
+            // remove a random entry
+            if (!cache.isEmpty()) {
+                String keyToRemove = cache.keys().nextElement();
+                cache.remove(keyToRemove);
+            }
+            return;
+        }
+
+        // Find LRU entry
+        String lruKey = null;
+        long minAccessOrder = Long.MAX_VALUE;
+
+        for (java.util.Map.Entry<String, CacheEntry> entry : cache.entrySet()) {
+            if (entry.getValue().accessOrder < minAccessOrder) {
+                minAccessOrder = entry.getValue().accessOrder;
+                lruKey = entry.getKey();
+            }
+        }
+
+        if (lruKey != null) {
+            cache.remove(lruKey);
+        }
+    }
+}

--- a/src/main/java/com/alibaba/qlexpress4/cache/ExpressionCache.java
+++ b/src/main/java/com/alibaba/qlexpress4/cache/ExpressionCache.java
@@ -1,0 +1,74 @@
+package com.alibaba.qlexpress4.cache;
+
+import com.alibaba.qlexpress4.aparser.QCompileCache;
+
+import java.util.concurrent.Future;
+
+/**
+ * Expression compilation cache interface.
+ * Provides cache operations for compiled expression results.
+ *
+ * Implementations can provide different cache strategies such as:
+ * - LRU (Least Recently Used) eviction
+ * - TTL (Time To Live) expiration
+ * - Size-based eviction
+ * - Custom eviction policies
+ *
+ * @author QLExpress Team
+ */
+public interface ExpressionCache {
+
+    /**
+     * Get cached compile result for the given script.
+     *
+     * @param script the expression script
+     * @return Future of compiled cache, or null if not cached
+     */
+    Future<QCompileCache> get(String script);
+
+    /**
+     * Put a compiled result into cache.
+     *
+     * @param script the expression script
+     * @param future the future of compiled result
+     * @return the previous value associated with script, or null if there was no mapping
+     */
+    Future<QCompileCache> put(String script, Future<QCompileCache> future);
+
+    /**
+     * Put a compiled result into cache if absent.
+     *
+     * @param script the expression script
+     * @param future the future of compiled result
+     * @return the existing value if present, or null if the new value was inserted
+     */
+    Future<QCompileCache> putIfAbsent(String script, Future<QCompileCache> future);
+
+    /**
+     * Remove a cached entry.
+     *
+     * @param script the expression script
+     * @return the removed value, or null if not present
+     */
+    Future<QCompileCache> remove(String script);
+
+    /**
+     * Clear all cached entries.
+     */
+    void clear();
+
+    /**
+     * Get the current cache size.
+     *
+     * @return number of cached entries
+     */
+    int size();
+
+    /**
+     * Check if cache contains the given script.
+     *
+     * @param script the expression script
+     * @return true if cached
+     */
+    boolean contains(String script);
+}

--- a/src/main/java/com/alibaba/qlexpress4/cache/SimpleExpressionCache.java
+++ b/src/main/java/com/alibaba/qlexpress4/cache/SimpleExpressionCache.java
@@ -1,0 +1,63 @@
+package com.alibaba.qlexpress4.cache;
+
+import com.alibaba.qlexpress4.aparser.QCompileCache;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+
+/**
+ * Simple unlimited expression cache implementation.
+ * Uses ConcurrentHashMap for thread-safe storage.
+ * <p>
+ * This implementation has no size limit or expiration mechanism.
+ * Suitable for scenarios with limited and predictable number of expressions.
+ *
+ * @author QLExpress Team
+ */
+public class SimpleExpressionCache implements ExpressionCache {
+
+    private final ConcurrentHashMap<String, Future<QCompileCache>> cache;
+
+    public SimpleExpressionCache() {
+        this.cache = new ConcurrentHashMap<>();
+    }
+
+    public SimpleExpressionCache(int initialCapacity) {
+        this.cache = new ConcurrentHashMap<>(initialCapacity);
+    }
+
+    @Override
+    public Future<QCompileCache> get(String script) {
+        return cache.get(script);
+    }
+
+    @Override
+    public Future<QCompileCache> put(String script, Future<QCompileCache> future) {
+        return cache.put(script, future);
+    }
+
+    @Override
+    public Future<QCompileCache> putIfAbsent(String script, Future<QCompileCache> future) {
+        return cache.putIfAbsent(script, future);
+    }
+
+    @Override
+    public Future<QCompileCache> remove(String script) {
+        return cache.remove(script);
+    }
+
+    @Override
+    public void clear() {
+        cache.clear();
+    }
+
+    @Override
+    public int size() {
+        return cache.size();
+    }
+
+    @Override
+    public boolean contains(String script) {
+        return cache.containsKey(script);
+    }
+}

--- a/src/test/java/com/alibaba/qlexpress4/cache/ExpressionCacheTest.java
+++ b/src/test/java/com/alibaba/qlexpress4/cache/ExpressionCacheTest.java
@@ -1,0 +1,236 @@
+package com.alibaba.qlexpress4.cache;
+
+import com.alibaba.qlexpress4.InitOptions;
+import com.alibaba.qlexpress4.Express4Runner;
+import com.alibaba.qlexpress4.QLOptions;
+import com.alibaba.qlexpress4.QLResult;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test cases for expression cache functionality.
+ */
+public class ExpressionCacheTest {
+
+    @Test
+    public void testDefaultCache() {
+        Express4Runner runner = new Express4Runner(InitOptions.DEFAULT_OPTIONS);
+
+        // Execute same script multiple times
+        String script = "1 + 2";
+        QLOptions options = QLOptions.builder().cache(true).build();
+
+        for (int i = 0; i < 5; i++) {
+            QLResult result = runner.execute(script, Collections.emptyMap(), options);
+            assertEquals(3, result.getResult());
+        }
+
+        // Cache should have 1 entry
+        assertEquals(1, runner.getCompileCacheSize());
+    }
+
+    @Test
+    public void testLRUCache() {
+        // Create cache with max size of 3
+        CacheConfig config = CacheConfig.lruConfig(3);
+        InitOptions initOptions = InitOptions.builder()
+            .cacheConfig(config)
+            .build();
+        Express4Runner runner = new Express4Runner(initOptions);
+        QLOptions options = QLOptions.builder().cache(true).build();
+
+        // Add 5 different scripts (only 3 should remain)
+        for (int i = 0; i < 5; i++) {
+            runner.execute("return " + i, Collections.emptyMap(), options);
+        }
+
+        // Cache size should be limited to 3
+        assertEquals(3, runner.getCompileCacheSize());
+    }
+
+    @Test
+    public void testTTLCache() throws InterruptedException {
+        // Create cache with 100ms TTL
+        CacheConfig config = CacheConfig.ttlConfig(100);
+        InitOptions initOptions = InitOptions.builder()
+            .cacheConfig(config)
+            .build();
+        Express4Runner runner = new Express4Runner(initOptions);
+        QLOptions options = QLOptions.builder().cache(true).build();
+
+        String script = "1 + 2";
+        runner.execute(script, Collections.emptyMap(), options);
+        assertEquals(1, runner.getCompileCacheSize());
+
+        // Wait for expiration
+        Thread.sleep(200);
+
+        // After expiration, cache entry should be expired and cleaned up
+        // Accessing size triggers cleanup
+        int size = runner.getCompileCacheSize();
+        assertEquals(0, size);
+    }
+
+    @Test
+    public void testLRUAndTTLCache() throws InterruptedException {
+        // Create cache with max size 5 and 1 second TTL
+        CacheConfig config = CacheConfig.lruAndTtlConfig(5, 1000);
+        InitOptions initOptions = InitOptions.builder()
+            .cacheConfig(config)
+            .build();
+        Express4Runner runner = new Express4Runner(initOptions);
+        QLOptions options = QLOptions.builder().cache(true).build();
+
+        // Add 3 scripts
+        for (int i = 0; i < 3; i++) {
+            runner.execute("return " + i, Collections.emptyMap(), options);
+        }
+        assertEquals(3, runner.getCompileCacheSize());
+
+        // Clear cache
+        runner.clearCompileCache();
+        assertEquals(0, runner.getCompileCacheSize());
+    }
+
+    @Test
+    public void testCustomCacheImplementation() {
+        // Create a custom cache that counts operations
+        AtomicInteger getCount = new AtomicInteger(0);
+        AtomicInteger putCount = new AtomicInteger(0);
+
+        ExpressionCache customCache = new ExpressionCache() {
+            private final java.util.concurrent.ConcurrentHashMap<String, java.util.concurrent.Future<com.alibaba.qlexpress4.aparser.QCompileCache>> cache =
+                new java.util.concurrent.ConcurrentHashMap<>();
+
+            @Override
+            public java.util.concurrent.Future<com.alibaba.qlexpress4.aparser.QCompileCache> get(String script) {
+                getCount.incrementAndGet();
+                return cache.get(script);
+            }
+
+            @Override
+            public java.util.concurrent.Future<com.alibaba.qlexpress4.aparser.QCompileCache> put(String script, java.util.concurrent.Future<com.alibaba.qlexpress4.aparser.QCompileCache> future) {
+                putCount.incrementAndGet();
+                return cache.put(script, future);
+            }
+
+            @Override
+            public java.util.concurrent.Future<com.alibaba.qlexpress4.aparser.QCompileCache> putIfAbsent(String script, java.util.concurrent.Future<com.alibaba.qlexpress4.aparser.QCompileCache> future) {
+                putCount.incrementAndGet();
+                return cache.putIfAbsent(script, future);
+            }
+
+            @Override
+            public java.util.concurrent.Future<com.alibaba.qlexpress4.aparser.QCompileCache> remove(String script) {
+                return cache.remove(script);
+            }
+
+            @Override
+            public void clear() {
+                cache.clear();
+            }
+
+            @Override
+            public int size() {
+                return cache.size();
+            }
+
+            @Override
+            public boolean contains(String script) {
+                return cache.containsKey(script);
+            }
+        };
+
+        InitOptions initOptions = InitOptions.builder()
+            .expressionCache(customCache)
+            .build();
+        Express4Runner runner = new Express4Runner(initOptions);
+        QLOptions options = QLOptions.builder().cache(true).build();
+
+        // Execute same script twice
+        String script = "1 + 2";
+        runner.execute(script, Collections.emptyMap(), options);
+        runner.execute(script, Collections.emptyMap(), options);
+
+        // First time: get (miss) + put
+        // Second time: get (hit)
+        assertTrue("Get should be called", getCount.get() >= 2);
+        assertTrue("Put should be called", putCount.get() >= 1);
+    }
+
+    @Test
+    public void testCacheConfigBuilder() {
+        CacheConfig config = CacheConfig.builder()
+            .maxSize(100)
+            .ttlMillis(60000)
+            .lruEnabled(true)
+            .initialCapacity(16)
+            .build();
+
+        assertEquals(100, config.getMaxSize());
+        assertEquals(60000, config.getTtlMillis());
+        assertTrue(config.isLruEnabled());
+        assertTrue(config.isMaxSizeEnabled());
+        assertTrue(config.isTtlEnabled());
+    }
+
+    @Test
+    public void testCacheConfigBuilderWithTimeUnit() {
+        CacheConfig config = CacheConfig.builder()
+            .maxSize(50)
+            .ttl(5, TimeUnit.MINUTES)
+            .build();
+
+        assertEquals(50, config.getMaxSize());
+        assertEquals(300000, config.getTtlMillis()); // 5 minutes in milliseconds
+    }
+
+    @Test
+    public void testSimpleExpressionCache() {
+        SimpleExpressionCache cache = new SimpleExpressionCache(10);
+        assertEquals(0, cache.size());
+
+        // Test put and get
+        java.util.concurrent.Future<com.alibaba.qlexpress4.aparser.QCompileCache> future =
+            new java.util.concurrent.FutureTask<>(() -> null);
+        cache.put("script1", future);
+        assertEquals(1, cache.size());
+        assertTrue(cache.contains("script1"));
+        assertEquals(future, cache.get("script1"));
+
+        // Test remove
+        cache.remove("script1");
+        assertEquals(0, cache.size());
+        assertFalse(cache.contains("script1"));
+
+        // Test clear
+        cache.put("script2", future);
+        cache.clear();
+        assertEquals(0, cache.size());
+    }
+
+    @Test
+    public void testDefaultCacheConfig() {
+        CacheConfig config = CacheConfig.defaultConfig();
+        assertEquals(-1, config.getMaxSize());
+        assertEquals(-1, config.getTtlMillis());
+        assertFalse(config.isLruEnabled());
+        assertFalse(config.isMaxSizeEnabled());
+        assertFalse(config.isTtlEnabled());
+    }
+
+    @Test
+    public void testCacheDisabled() {
+        Express4Runner runner = new Express4Runner(InitOptions.DEFAULT_OPTIONS);
+        QLOptions options = QLOptions.builder().cache(false).build();
+
+        // Execute script without cache
+        runner.execute("1 + 2", Collections.emptyMap(), options);
+        assertEquals(0, runner.getCompileCacheSize());
+    }
+}


### PR DESCRIPTION
This commit introduces a new ExpressionCache interface that allows users to provide custom cache implementations for compiled expressions.

Features:
- ExpressionCache interface for custom cache implementations
- DefaultExpressionCache with LRU eviction and TTL expiration
- CacheConfig with builder pattern for flexible configuration
- SimpleExpressionCache as default thread-safe unlimited cache
- Integration with Express4Runner and InitOptions

Usage example:
  CacheConfig config = CacheConfig.builder() .maxSize(1000) .ttl(10, TimeUnit.MINUTES) .lruEnabled(true) .build(); InitOptions options = InitOptions.builder() .cacheConfig(config) .build(); Express4Runner runner = new Express4Runner(options);

Documentation updated in README-source.adoc and README-EN-source.adoc.