### PR TITLE
添加 LazyArgCustomFunction 扩展点，支持延迟参数求值，实现自定义函数的控制流

### DIFF
--- a/README-EN-source.adoc
+++ b/README-EN-source.adoc
@@ -159,6 +159,19 @@ include::./src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java[tag=addF
 
 It is recommended to use Java to define custom functions as much as possible, as this can provide better performance and stability.
 
+==== Lazy Argument Evaluation (LazyArgCustomFunction)
+
+By default, QLExpress evaluates all arguments before calling a function. If evaluating an argument causes side effects (such as a division-by-zero error), the error is triggered even if the function logic does not need that argument.
+
+Functions that implement the `LazyArgCustomFunction` interface control when arguments are evaluated. The compiler wraps each argument as a `QLambda`, and the function manually triggers evaluation by calling `QLambda.get()`, enabling short-circuit evaluation semantics.
+
+[source,java,indent=0]
+----
+include::./src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java[tag=lazyArgCustomFunction]
+----
+
+In the example above, when `b == 0` is true, the third argument `a / b` is never evaluated, so no division-by-zero exception is thrown.
+
 For more ways to customize syntax elements, see the documentation link:docs/custom-item-en.adoc[Custom Syntax Elements].
 
 === Validating Syntax Correctness

--- a/README-EN-source.adoc
+++ b/README-EN-source.adoc
@@ -163,7 +163,7 @@ It is recommended to use Java to define custom functions as much as possible, as
 
 By default, QLExpress evaluates all arguments before calling a function. If evaluating an argument causes side effects (such as a division-by-zero error), the error is triggered even if the function logic does not need that argument.
 
-Functions that implement the `LazyArgCustomFunction` interface control when arguments are evaluated. The compiler wraps each argument as a `QLambda`, and the function manually triggers evaluation by calling `QLambda.get()`, enabling short-circuit evaluation semantics.
+Functions that implement the `LazyArgCustomFunction` interface control when arguments are evaluated. By default, the compiler wraps each argument as a `QLambda`, this behavior can be customized by overriding `isLazyArg(int argIndex)`, and the function manually triggers evaluation by calling `QLambda.get()`, enabling short-circuit evaluation semantics.
 
 [source,java,indent=0]
 ----

--- a/README-source.adoc
+++ b/README-source.adoc
@@ -164,7 +164,7 @@ include::./src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java[tag=addF
 
 默认情况下，QLExpress 在调用函数前会先对所有参数完成求值。如果某个参数的计算会产生副作用（如除零异常），即使函数逻辑上不需要该参数，也会在调用前触发错误。
 
-实现 `LazyArgCustomFunction` 接口的函数可以控制参数的求值时机。编译器会将每个参数包装为 `QLambda`，函数内部通过调用 `QLambda.get()` 手动触发求值，从而实现短路求值语义。
+实现 `LazyArgCustomFunction` 接口的函数可以控制参数的求值时机。编译器默认会将每个参数包装为 `QLambda`，也可以通过 `isLazyArg(int argIndex)` 指定部分参数，函数内部通过调用 `QLambda.get()` 手动触发求值，从而实现短路求值语义。
 
 [source,java,indent=0]
 ----

--- a/README-source.adoc
+++ b/README-source.adoc
@@ -160,6 +160,19 @@ include::./src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java[tag=addF
 
 建议尽可能使用Java方式定义自定义函数，这样可以获得更好的性能和稳定性。
 
+==== 延迟参数求值函数（LazyArgCustomFunction）
+
+默认情况下，QLExpress 在调用函数前会先对所有参数完成求值。如果某个参数的计算会产生副作用（如除零异常），即使函数逻辑上不需要该参数，也会在调用前触发错误。
+
+实现 `LazyArgCustomFunction` 接口的函数可以控制参数的求值时机。编译器会将每个参数包装为 `QLambda`，函数内部通过调用 `QLambda.get()` 手动触发求值，从而实现短路求值语义。
+
+[source,java,indent=0]
+----
+include::./src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java[tag=lazyArgCustomFunction]
+----
+
+上例中，当 `b == 0` 条件成立时，第三个参数 `a / b` 不会被求值，因此不会触发除零异常。
+
 更多自定义语法元素的方式见文档 link:docs/custom-item.adoc[自定义语法元素]
 
 === 校验语法正确性

--- a/src/main/java/com/alibaba/qlexpress4/Express4Runner.java
+++ b/src/main/java/com/alibaba/qlexpress4/Express4Runner.java
@@ -313,7 +313,7 @@ public class Express4Runner {
         QLParser.ProgramContext macroProgram = parseToSyntaxTree(macroScript);
         QvmInstructionVisitor macroVisitor = new QvmInstructionVisitor(macroScript, inheritDefaultImport(),
             new GeneratorScope("MACRO_" + name, globalScope), operatorManager, QvmInstructionVisitor.Context.MACRO,
-            compileTimeFunctions, initOptions);
+            compileTimeFunctions, userDefineFunction, initOptions);
         macroProgram.accept(macroVisitor);
         List<QLInstruction> macroInstructions = macroVisitor.getInstructions();
         List<QLParser.BlockStatementContext> blockStatementContexts = macroProgram.blockStatements().blockStatement();
@@ -679,7 +679,7 @@ public class Express4Runner {
     private QCompileCache parseDefinition(String script) {
         QLParser.ProgramContext program = parseToSyntaxTree(script);
         QvmInstructionVisitor qvmInstructionVisitor = new QvmInstructionVisitor(script, inheritDefaultImport(),
-            globalScope, operatorManager, compileTimeFunctions, initOptions);
+            globalScope, operatorManager, compileTimeFunctions, userDefineFunction, initOptions);
         program.accept(qvmInstructionVisitor);
         
         QLambdaDefinitionInner qLambdaDefinition = new QLambdaDefinitionInner("main",

--- a/src/main/java/com/alibaba/qlexpress4/aparser/QvmInstructionVisitor.java
+++ b/src/main/java/com/alibaba/qlexpress4/aparser/QvmInstructionVisitor.java
@@ -39,6 +39,8 @@ public class QvmInstructionVisitor extends QLParserBaseVisitor<Void> {
     private static final String MACRO_PREFIX = "MACRO_";
     
     private static final String LAMBDA_PREFIX = "LAMBDA_";
+
+    private static final String LAZY_FUNCTION_PREFIX = "LAZY_FUNCTION_";
     
     private static final String TRY_PREFIX = "TRY_";
     
@@ -105,6 +107,8 @@ public class QvmInstructionVisitor extends QLParserBaseVisitor<Void> {
     private int macroCounter = 0;
     
     private int lambdaCounter = 0;
+
+    private int lazyFunctionCounter = 0;
     
     private int tryCounter = 0;
     
@@ -1589,14 +1593,18 @@ public class QvmInstructionVisitor extends QLParserBaseVisitor<Void> {
             CustomFunction customFunction = userDefineFunctions.get(functionName);
             if (customFunction instanceof LazyArgCustomFunction) {
                 List<ExpressionContext> exprs = argumentListContext.expression();
+                int lazyFunctionCount = lazyFunctionCount();
                 for (int i = 0; i < exprs.size(); i++) {
                     ExpressionContext expr = exprs.get(i);
                     if (!((LazyArgCustomFunction) customFunction).isLazyArg(i)) {
                         expr.accept(this);
                         continue;
                     }
-                    QvmInstructionVisitor lazyVisitor = parseExprBodyWithSubVisitor(expr, generatorScope, context);
-                    String scopeName = functionName + "$lazy" + i;
+                    String scopeName = generatorScope.getName() + SCOPE_SEPARATOR + LAZY_FUNCTION_PREFIX + lazyFunctionCount
+                        + "_" + functionName + i;
+                    QvmInstructionVisitor lazyVisitor = parseExprBodyWithSubVisitor(expr,
+                        new GeneratorScope(scopeName, generatorScope),
+                        Context.BLOCK);
                     QLambdaDefinitionInner lazyLambda = new QLambdaDefinitionInner(scopeName,
                         lazyVisitor.getInstructions(), Collections.emptyList(), lazyVisitor.getMaxStackSize());
                     addInstruction(new LoadLambdaInstruction(newReporterWithToken(expr.getStart()), lazyLambda));
@@ -2082,6 +2090,10 @@ public class QvmInstructionVisitor extends QLParserBaseVisitor<Void> {
     
     private int switchCount() {
         return switchCounter++;
+    }
+
+    private int lazyFunctionCount() {
+        return lazyFunctionCounter++;
     }
     
     private int tryCount() {

--- a/src/main/java/com/alibaba/qlexpress4/aparser/QvmInstructionVisitor.java
+++ b/src/main/java/com/alibaba/qlexpress4/aparser/QvmInstructionVisitor.java
@@ -1591,6 +1591,10 @@ public class QvmInstructionVisitor extends QLParserBaseVisitor<Void> {
                 List<ExpressionContext> exprs = argumentListContext.expression();
                 for (int i = 0; i < exprs.size(); i++) {
                     ExpressionContext expr = exprs.get(i);
+                    if (!((LazyArgCustomFunction) customFunction).isLazyArg(i)) {
+                        expr.accept(this);
+                        continue;
+                    }
                     QvmInstructionVisitor lazyVisitor = parseExprBodyWithSubVisitor(expr, generatorScope, context);
                     String scopeName = functionName + "$lazy" + i;
                     QLambdaDefinitionInner lazyLambda = new QLambdaDefinitionInner(scopeName,

--- a/src/main/java/com/alibaba/qlexpress4/aparser/QvmInstructionVisitor.java
+++ b/src/main/java/com/alibaba/qlexpress4/aparser/QvmInstructionVisitor.java
@@ -1585,25 +1585,24 @@ public class QvmInstructionVisitor extends QLParserBaseVisitor<Void> {
             return;
         }
         
-        int argSize = argumentListContext == null ? 0 : argumentListContext.expression().size();
-        CustomFunction customFunction = userDefineFunctions.get(functionName);
         if (argumentListContext != null) {
+            CustomFunction customFunction = userDefineFunctions.get(functionName);
             if (customFunction instanceof LazyArgCustomFunction) {
                 List<ExpressionContext> exprs = argumentListContext.expression();
                 for (int i = 0; i < exprs.size(); i++) {
-                    QvmInstructionVisitor lazyVisitor =
-                        parseExprBodyWithSubVisitor(exprs.get(i), generatorScope, context);
+                    ExpressionContext expr = exprs.get(i);
+                    QvmInstructionVisitor lazyVisitor = parseExprBodyWithSubVisitor(expr, generatorScope, context);
                     String scopeName = functionName + "$lazy" + i;
                     QLambdaDefinitionInner lazyLambda = new QLambdaDefinitionInner(scopeName,
                         lazyVisitor.getInstructions(), Collections.emptyList(), lazyVisitor.getMaxStackSize());
-                    addInstruction(
-                        new LoadLambdaInstruction(newReporterWithToken(exprs.get(i).getStart()), lazyLambda));
+                    addInstruction(new LoadLambdaInstruction(newReporterWithToken(expr.getStart()), lazyLambda));
                 }
             }
             else {
                 argumentListContext.accept(this);
             }
         }
+        int argSize = argumentListContext == null ? 0 : argumentListContext.expression().size();
         addInstruction(new CallFunctionInstruction(newReporterWithToken(functionNameContext.getStart()), functionName,
             argSize, functionNameContext.getStart().getStartIndex()));
     }

--- a/src/main/java/com/alibaba/qlexpress4/aparser/QvmInstructionVisitor.java
+++ b/src/main/java/com/alibaba/qlexpress4/aparser/QvmInstructionVisitor.java
@@ -6,6 +6,8 @@ import com.alibaba.qlexpress4.aparser.compiletimefunction.CodeGenerator;
 import com.alibaba.qlexpress4.aparser.compiletimefunction.CompileTimeFunction;
 import com.alibaba.qlexpress4.exception.*;
 import com.alibaba.qlexpress4.runtime.*;
+import com.alibaba.qlexpress4.runtime.function.CustomFunction;
+import com.alibaba.qlexpress4.runtime.function.LazyArgCustomFunction;
 import com.alibaba.qlexpress4.runtime.instruction.*;
 import com.alibaba.qlexpress4.runtime.operator.BinaryOperator;
 import com.alibaba.qlexpress4.runtime.operator.OperatorManager;
@@ -82,6 +84,8 @@ public class QvmInstructionVisitor extends QLParserBaseVisitor<Void> {
     
     private final Map<String, CompileTimeFunction> compileTimeFunctions;
     
+    private final Map<String, CustomFunction> userDefineFunctions;
+    
     private final InitOptions initOptions;
     
     private final Context context;
@@ -115,13 +119,14 @@ public class QvmInstructionVisitor extends QLParserBaseVisitor<Void> {
      */
     public QvmInstructionVisitor(String script, ImportManager importManager, GeneratorScope globalScope,
         OperatorFactory operatorFactory, Map<String, CompileTimeFunction> compileTimeFunctions,
-        InitOptions initOptions) {
+        Map<String, CustomFunction> userDefineFunctions, InitOptions initOptions) {
         this.script = script;
         this.importManager = importManager;
         this.generatorScope = new GeneratorScope("main", globalScope);
         this.operatorFactory = operatorFactory;
         this.context = Context.BLOCK;
         this.compileTimeFunctions = compileTimeFunctions;
+        this.userDefineFunctions = userDefineFunctions;
         this.initOptions = initOptions;
     }
     
@@ -130,13 +135,14 @@ public class QvmInstructionVisitor extends QLParserBaseVisitor<Void> {
      */
     public QvmInstructionVisitor(String script, ImportManager importManager, GeneratorScope generatorScope,
         OperatorFactory operatorFactory, Context context, Map<String, CompileTimeFunction> compileTimeFunctions,
-        InitOptions initOptions) {
+        Map<String, CustomFunction> userDefineFunctions, InitOptions initOptions) {
         this.script = script;
         this.importManager = importManager;
         this.generatorScope = generatorScope;
         this.operatorFactory = operatorFactory;
         this.context = context;
         this.compileTimeFunctions = compileTimeFunctions;
+        this.userDefineFunctions = userDefineFunctions;
         this.initOptions = initOptions;
     }
     
@@ -150,6 +156,7 @@ public class QvmInstructionVisitor extends QLParserBaseVisitor<Void> {
         this.operatorFactory = new OperatorManager();
         this.context = Context.BLOCK;
         this.compileTimeFunctions = new HashMap<>();
+        this.userDefineFunctions = new HashMap<>();
         this.initOptions = InitOptions.DEFAULT_OPTIONS;
     }
     
@@ -1578,10 +1585,25 @@ public class QvmInstructionVisitor extends QLParserBaseVisitor<Void> {
             return;
         }
         
-        if (argumentListContext != null) {
-            argumentListContext.accept(this);
-        }
         int argSize = argumentListContext == null ? 0 : argumentListContext.expression().size();
+        CustomFunction customFunction = userDefineFunctions.get(functionName);
+        if (argumentListContext != null) {
+            if (customFunction instanceof LazyArgCustomFunction) {
+                List<ExpressionContext> exprs = argumentListContext.expression();
+                for (int i = 0; i < exprs.size(); i++) {
+                    QvmInstructionVisitor lazyVisitor =
+                        parseExprBodyWithSubVisitor(exprs.get(i), generatorScope, context);
+                    String scopeName = functionName + "$lazy" + i;
+                    QLambdaDefinitionInner lazyLambda = new QLambdaDefinitionInner(scopeName,
+                        lazyVisitor.getInstructions(), Collections.emptyList(), lazyVisitor.getMaxStackSize());
+                    addInstruction(
+                        new LoadLambdaInstruction(newReporterWithToken(exprs.get(i).getStart()), lazyLambda));
+                }
+            }
+            else {
+                argumentListContext.accept(this);
+            }
+        }
         addInstruction(new CallFunctionInstruction(newReporterWithToken(functionNameContext.getStart()), functionName,
             argSize, functionNameContext.getStart().getStartIndex()));
     }
@@ -1965,7 +1987,7 @@ public class QvmInstructionVisitor extends QLParserBaseVisitor<Void> {
     private QvmInstructionVisitor parseWithSubVisitor(RuleContext ruleContext, GeneratorScope generatorScope,
         Context context) {
         QvmInstructionVisitor subVisitor = new QvmInstructionVisitor(script, importManager, generatorScope,
-            operatorFactory, context, compileTimeFunctions, initOptions);
+            operatorFactory, context, compileTimeFunctions, userDefineFunctions, initOptions);
         ruleContext.accept(subVisitor);
         return subVisitor;
     }
@@ -1973,7 +1995,7 @@ public class QvmInstructionVisitor extends QLParserBaseVisitor<Void> {
     private QvmInstructionVisitor parseExprBodyWithSubVisitor(ExpressionContext expressionContext,
         GeneratorScope generatorScope, Context context) {
         QvmInstructionVisitor subVisitor = new QvmInstructionVisitor(script, importManager, generatorScope,
-            operatorFactory, context, compileTimeFunctions, initOptions);
+            operatorFactory, context, compileTimeFunctions, userDefineFunctions, initOptions);
         // reduce the level of syntax tree when expression is a block
         subVisitor.visitBodyExpression(expressionContext);
         return subVisitor;

--- a/src/main/java/com/alibaba/qlexpress4/runtime/function/LazyArgCustomFunction.java
+++ b/src/main/java/com/alibaba/qlexpress4/runtime/function/LazyArgCustomFunction.java
@@ -1,9 +1,17 @@
 package com.alibaba.qlexpress4.runtime.function;
 
 /**
- * 实现控制流函数,函数内的参数不会在编译阶段求值,而是在运行阶段求值
- * 参数会以 QLambda 形式传入，需要手动调用 .get() 触发求值
+ * A custom function that can control whether individual arguments are lazily evaluated.
  * Author: zimoa
  */
 public interface LazyArgCustomFunction extends CustomFunction {
+    /**
+     * Determine whether the current argument should be evaluated lazily.
+     *
+     * @param argIndex zero-based argument index in the function call
+     * @return true to delay evaluation
+     */
+    default boolean isLazyArg(int argIndex) {
+        return true;
+    }
 }

--- a/src/main/java/com/alibaba/qlexpress4/runtime/function/LazyArgCustomFunction.java
+++ b/src/main/java/com/alibaba/qlexpress4/runtime/function/LazyArgCustomFunction.java
@@ -1,0 +1,9 @@
+package com.alibaba.qlexpress4.runtime.function;
+
+/**
+ * 实现控制流函数,函数内的参数不会在编译阶段求值,而是在运行阶段求值
+ * 参数会以 QLambda 形式传入，需要手动调用 .get() 触发求值
+ * Author: zimoa
+ */
+public interface LazyArgCustomFunction extends CustomFunction {
+}

--- a/src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java
+++ b/src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java
@@ -11,11 +11,15 @@ import com.alibaba.qlexpress4.exception.QLRuntimeException;
 import com.alibaba.qlexpress4.exception.QLSyntaxException;
 import com.alibaba.qlexpress4.exception.QLTimeoutException;
 import com.alibaba.qlexpress4.inport.MyDesk;
+import com.alibaba.qlexpress4.runtime.Parameters;
+import com.alibaba.qlexpress4.runtime.QContext;
+import com.alibaba.qlexpress4.runtime.QLambda;
 import com.alibaba.qlexpress4.runtime.Value;
 import com.alibaba.qlexpress4.runtime.context.DynamicVariableContext;
 import com.alibaba.qlexpress4.runtime.context.ExpressContext;
 import com.alibaba.qlexpress4.runtime.data.DataValue;
 import com.alibaba.qlexpress4.runtime.function.ExtensionFunction;
+import com.alibaba.qlexpress4.runtime.function.LazyArgCustomFunction;
 import com.alibaba.qlexpress4.runtime.trace.ExpressionTrace;
 import com.alibaba.qlexpress4.runtime.trace.TracePointTree;
 import com.alibaba.qlexpress4.security.QLSecurityStrategy;
@@ -1851,5 +1855,72 @@ public class Express4RunnerTest {
         QLResult result = express4Runner
             .execute("default = 1\nswitch = 2;\ndefault+switch", Collections.emptyMap(), QLOptions.DEFAULT_OPTIONS);
         assertEquals(3, result.getResult());
+    }
+    
+    @Test
+    public void testLazyArgCustomFunction() {
+        // tag::lazyArgCustomFunction[]
+        Express4Runner express4Runner = new Express4Runner(InitOptions.DEFAULT_OPTIONS);
+        express4Runner.addFunction("IF", new LazyArgCustomFunction() {
+            private static final int PARAM_LENGTH = 3;
+            
+            @Override
+            public Object call(QContext qContext, Parameters parameters) {
+                if (parameters == null || parameters.size() != PARAM_LENGTH) {
+                    throw new IllegalArgumentException("Invalid number of arguments");
+                }
+                Object v1 = call(parameters.getValue(0));
+                if (!(v1 instanceof Boolean)) {
+                    throw new IllegalArgumentException("Argument 1 must be a boolean");
+                }
+                if ((Boolean)v1) {
+                    return call(parameters.getValue(1));
+                }
+                
+                return call(parameters.getValue(2));
+            }
+            
+            private Object call(Object obj) {
+                if (obj instanceof QLambda) {
+                    return ((QLambda)obj).get();
+                }
+                return obj;
+            }
+        });
+        // end::lazyArgCustomFunction[]
+        
+        Map<String, Object> context = new HashMap<>();
+        context.put("a", 10000d);
+        context.put("b", 0);
+        
+        // Should return 0 when b equals 0
+        QLResult result = express4Runner.execute("IF(b == 0, 0, a / b)", context, QLOptions.DEFAULT_OPTIONS);
+        assertEquals(0, result.getResult());
+        
+        // Should return 500 when c equals 20
+        context.put("c", 20);
+        QLResult result2 = express4Runner.execute("IF(c == 0, 0, a / c)", context, QLOptions.DEFAULT_OPTIONS);
+        assertEquals(500d, result2.getResult());
+        
+        // Nested IF
+        QLResult result3 = express4Runner.execute("IF(false, 0, IF(true, 1, 0))", context, QLOptions.DEFAULT_OPTIONS);
+        assertEquals(1, result3.getResult());
+        
+        // Variable addition and subtraction
+        context.put("base", 100);
+        QLResult result4 = express4Runner.execute("IF(true, base + 1, base - 1)", context, QLOptions.DEFAULT_OPTIONS);
+        assertEquals(101, result4.getResult());
+        
+        // Null
+        context.put("a", null);
+        QLResult result5 = express4Runner.execute("IF(true, null, null)", context, QLOptions.DEFAULT_OPTIONS);
+        assertNull(result5.getResult());
+        
+        // other
+        express4Runner.check("IF(b == 0, 0, a / b)");
+        Set<String> result6 = express4Runner.getOutFunctions("IF(b == 0, 0, a / b)");
+        assertArrayEquals(new String[] {"IF"}, result6.toArray());
+        Set<String> result7 = express4Runner.getOutVarNames("IF(b == 0, 0, a / b)");
+        assertArrayEquals(new String[] {"a", "b"}, result7.toArray());
     }
 }

--- a/src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java
+++ b/src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java
@@ -1863,7 +1863,12 @@ public class Express4RunnerTest {
         Express4Runner express4Runner = new Express4Runner(InitOptions.DEFAULT_OPTIONS);
         express4Runner.addFunction("IF", new LazyArgCustomFunction() {
             private static final int PARAM_LENGTH = 3;
-            
+
+            @Override
+            public boolean isLazyArg(int argIndex) {
+                return 1 == argIndex || 2 == argIndex;
+            }
+
             @Override
             public Object call(QContext qContext, Parameters parameters) {
                 if (parameters == null || parameters.size() != PARAM_LENGTH) {
@@ -1890,7 +1895,7 @@ public class Express4RunnerTest {
         // end::lazyArgCustomFunction[]
         
         Map<String, Object> context = new HashMap<>();
-        context.put("a", 10000d);
+        context.put("a", 10000);
         context.put("b", 0);
         
         // Should return 0 when b equals 0
@@ -1899,8 +1904,8 @@ public class Express4RunnerTest {
         
         // Should return 500 when c equals 20
         context.put("c", 20);
-        QLResult result2 = express4Runner.execute("IF(c == 0, 0, a / c)", context, QLOptions.DEFAULT_OPTIONS);
-        assertEquals(500d, result2.getResult());
+        QLResult result2 = express4Runner.execute("IF(c != 0, a / c, 0)", context, QLOptions.DEFAULT_OPTIONS);
+        assertEquals(new BigDecimal("500"), result2.getResult());
         
         // Nested IF
         QLResult result3 = express4Runner.execute("IF(false, 0, IF(true, 1, 0))", context, QLOptions.DEFAULT_OPTIONS);

--- a/src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java
+++ b/src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java
@@ -1923,4 +1923,22 @@ public class Express4RunnerTest {
         Set<String> result7 = express4Runner.getOutVarNames("IF(b == 0, 0, a / b)");
         assertArrayEquals(new String[] {"a", "b"}, result7.toArray());
     }
+    
+    @Test
+    public void testLazyArgCustomFunctionNoArgs() {
+        Express4Runner express4Runner = new Express4Runner(InitOptions.DEFAULT_OPTIONS);
+        express4Runner.addFunction("CURRENT_TIME", new LazyArgCustomFunction() {
+            
+            @Override
+            public Object call(QContext qContext, Parameters parameters) {
+                return System.currentTimeMillis();
+            }
+        });
+        
+        Map<String, Object> context = new HashMap<>();
+        
+        // Should return
+        QLResult result = express4Runner.execute("CURRENT_TIME()", context, QLOptions.DEFAULT_OPTIONS);
+        assertTrue((Long)result.getResult() > 0);
+    }
 }

--- a/src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java
+++ b/src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java
@@ -1918,15 +1918,29 @@ public class Express4RunnerTest {
         
         // Null
         context.put("a", null);
-        QLResult result5 = express4Runner.execute("IF(true, null, null)", context, QLOptions.DEFAULT_OPTIONS);
+        QLResult result5 = express4Runner.execute("IF(true, a, b)", context, QLOptions.DEFAULT_OPTIONS);
         assertNull(result5.getResult());
         
-        // other
+        // Other
         express4Runner.check("IF(b == 0, 0, a / b)");
         Set<String> result6 = express4Runner.getOutFunctions("IF(b == 0, 0, a / b)");
         assertArrayEquals(new String[] {"IF"}, result6.toArray());
         Set<String> result7 = express4Runner.getOutVarNames("IF(b == 0, 0, a / b)");
         assertArrayEquals(new String[] {"a", "b"}, result7.toArray());
+        QLResult result8 = express4Runner.execute("IF(false, 0, IF(true, IF(true, IF(true, IF(true, 1, 0), 0), 0), 0))", context, QLOptions.DEFAULT_OPTIONS);
+        assertEquals(1, result8.getResult());
+        QLResult result9 = express4Runner.execute("IF(true, 1, 0) + IF(true, 1, 0) + IF(false, IF(true, 1, 0), 0)", context, QLOptions.DEFAULT_OPTIONS);
+        assertEquals(2, result9.getResult());
+        QLResult result10 = express4Runner.execute("tmp=0; tmp++; if(tmp>0) then IF(true, 1, 0) else 0", context, QLOptions.DEFAULT_OPTIONS);
+        assertEquals(1, result10.getResult());
+        QLResult result11 = express4Runner.execute("function func(x){ x++; return x+b; } IF(true, func(0), 0)", context, QLOptions.DEFAULT_OPTIONS);
+        assertEquals(1, result11.getResult());
+        QLResult result12 = express4Runner.execute("func = (x) -> { x++; return x; } \nIF(true, func(0), 0)", context, QLOptions.DEFAULT_OPTIONS);
+        assertEquals(1, result12.getResult());
+        QLResult result13 = express4Runner.execute("true ? IF(false, {a}, {b}) : 0", context, QLOptions.DEFAULT_OPTIONS);
+        assertEquals(0, result13.getResult());
+        QLResult result14 = express4Runner.execute("true ? IF(true, {1}, {2}) : 0", context, QLOptions.DEFAULT_OPTIONS);
+        assertEquals(1, result14.getResult());
     }
     
     @Test


### PR DESCRIPTION
关联 Issue：close #333                                                                                                                                                                                                                                                                                                                                                                       
                        
  ## 背景    
                                        
  `CustomFunction` 在函数调用前会对所有参数提前求值。这导致无法实现控制流类函数，例如 `IF(condition, thenExpr, elseExpr)` — 即使条件为 `true`，`elseExpr` 中的 `a / b`（`b == 0`）也会触发除零异常。

  ## 方案

  新增 `LazyArgCustomFunction` 接口（继承自 `CustomFunction`）。

  当函数实现该接口时，编译器会将每个参数包装为 `QLambda` 而非提前求值，函数内部通过调用 `QLambda.get()` 手动控制每个参数的求值时机，从而实现短路求值语义。

  ## 示例

  ```java
  express4Runner.addFunction("IF", new LazyArgCustomFunction() {
      @Override
      public Object call(QContext qContext, Parameters parameters) {
          boolean condition = (Boolean) eval(parameters.getValue(0));
          return condition ? eval(parameters.getValue(1)) : eval(parameters.getValue(2));
      }

      private Object eval(Object obj) {
          return obj instanceof QLambda ? ((QLambda) obj).get() : obj;
      }
  });

  // b == 0 时，第三个参数 a / b 不会被求值，不会触发除零异常
  express4Runner.execute("IF(b == 0, 0, a / b)", context, QLOptions.DEFAULT_OPTIONS);
```

  改动说明

  - LazyArgCustomFunction：新增接口，位于 runtime/function/
  - QvmInstructionVisitor：识别 LazyArgCustomFunction，将参数包装为 QLambda
  - Express4Runner：向 QvmInstructionVisitor 传入 userDefineFunction 映射
  - Express4RunnerTest：新增测试用例
  - README-source.adoc / README-EN-source.adoc：补充扩展点使用文档


  
  切入流程

```
用户代码
  ↓
Express4Runner (入口点)
  ├─→ [编译阶段]
  │   ├─ SyntaxTreeFactory: 构建 ANTLR 语法树
  │   ├─ QvmInstructionVisitor: 遍历语法树生成指令
  │   │   └─  * 函数调用编译: 查询用户注册函数类型
  │   │       ├─ CustomFunction → 参数正常求值，生成普通指令序列
  │   │       └─ LazyArgCustomFunction → 参数包装为 QLambda，生成 LoadLambdaInstruction
  │   └─ QCompileCache: 缓存编译结果
  │
... 
