### PR TITLE
feat: support bounded compile cache via Caffeine

### DIFF
--- a/README-EN-source.adoc
+++ b/README-EN-source.adoc
@@ -380,7 +380,25 @@ You can cache scripts before first execution using the following method to ensur
 include::./src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java[tag=parseToCache]
 ----
 
-Note that this cache has an unlimited size; be sure to control its size in your application. You can periodically clear the compilation cache by calling the `clearCompileCache` method.
+Note that this cache has an unlimited size by default; be sure to control its size in your application. You can periodically clear the compilation cache by calling the `clearCompileCache` method.
+
+==== Bounding the Compile Cache
+
+If you are concerned that the compile cache will grow without bound as new scripts arrive, you can configure a Caffeine-backed bounded cache through `InitOptions`. Setting `compileCacheMaxSize` caps the number of entries; Caffeine evicts less-used entries using its Window TinyLFU policy when the cap is exceeded:
+
+[source,java,indent=0]
+----
+include::./src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java[tag=compileCacheMaxSize]
+----
+
+You can also drop scripts that have not been read for a while by setting `compileCacheExpireAfterAccess`. The parameter is a `java.time.Duration`, so any time unit is allowed:
+
+[source,java,indent=0]
+----
+include::./src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java[tag=compileCacheExpireAfterAccess]
+----
+
+`compileCacheMaxSize` defaults to `-1` and `compileCacheExpireAfterAccess` defaults to `null`; both disable the corresponding limit and preserve the prior unbounded behavior. `Express4Runner#compileCacheSize` reports the current number of entries, which is handy for monitoring.
 
 === Clearing DFA Cache
 

--- a/README-source.adoc
+++ b/README-source.adoc
@@ -381,7 +381,25 @@ include::./src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java[tag=cach
 include::./src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java[tag=parseToCache]
 ----
 
-注意该缓存的大小是无限的，业务上注意控制大小，可以调用 `clearCompileCache` 方法定期清空编译缓存。
+注意该缓存的大小默认是无限的，业务上注意控制大小，可以调用 `clearCompileCache` 方法定期清空编译缓存。
+
+==== 限制编译缓存大小
+
+如果你担心缓存随着脚本数量增长而无限累积，可以在 `InitOptions` 上配置基于 Caffeine 的有界缓存。设置 `compileCacheMaxSize` 后，缓存条目数量超过该上限时，Caffeine 会按照 Window TinyLFU 策略自动淘汰较少使用的条目：
+
+[source,java,indent=0]
+----
+include::./src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java[tag=compileCacheMaxSize]
+----
+
+也可以通过 `compileCacheExpireAfterAccess` 让长时间未访问的脚本自动从缓存中过期，参数类型为 `java.time.Duration`，方便指定任意时间单位：
+
+[source,java,indent=0]
+----
+include::./src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java[tag=compileCacheExpireAfterAccess]
+----
+
+`compileCacheMaxSize` 默认值为 `-1`，`compileCacheExpireAfterAccess` 默认值为 `null`，均表示不启用对应的限制，行为与之前一致。可以通过 `Express4Runner#compileCacheSize` 查看当前缓存中的条目数量，方便监控。
 
 === 清除 DFA 缓存
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@
             <version>4.9.3</version>
         </dependency>
         <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+            <version>2.9.3</version>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>

--- a/src/main/java/com/alibaba/qlexpress4/Express4Runner.java
+++ b/src/main/java/com/alibaba/qlexpress4/Express4Runner.java
@@ -41,19 +41,20 @@ import com.alibaba.qlexpress4.runtime.trace.QTraces;
 import com.alibaba.qlexpress4.runtime.trace.TracePointTree;
 import com.alibaba.qlexpress4.utils.BasicUtil;
 import com.alibaba.qlexpress4.utils.QLFunctionUtil;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.antlr.v4.runtime.dfa.DFA;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Future;
-import java.util.concurrent.FutureTask;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -65,22 +66,35 @@ import java.util.stream.Collectors;
  */
 public class Express4Runner {
     private final OperatorManager operatorManager = new OperatorManager();
-    
-    private final Map<String, Future<QCompileCache>> compileCache = new ConcurrentHashMap<>();
-    
+
+    private final Cache<String, QCompileCache> compileCache;
+
     private final Map<String, CustomFunction> userDefineFunction = new ConcurrentHashMap<>();
-    
+
     private final Map<String, CompileTimeFunction> compileTimeFunctions = new ConcurrentHashMap<>();
-    
+
     private final GeneratorScope globalScope = new GeneratorScope(null, "global", new ConcurrentHashMap<>());
-    
+
     private final ReflectLoader reflectLoader;
-    
+
     private final InitOptions initOptions;
-    
+
     public Express4Runner(InitOptions initOptions) {
         this.initOptions = initOptions;
         this.reflectLoader = new ReflectLoader(initOptions.getSecurityStrategy(), initOptions.isAllowPrivateAccess());
+        this.compileCache = buildCompileCache(initOptions);
+    }
+
+    private static Cache<String, QCompileCache> buildCompileCache(InitOptions initOptions) {
+        Caffeine<Object, Object> builder = Caffeine.newBuilder();
+        if (initOptions.getCompileCacheMaxSize() > 0) {
+            builder.maximumSize(initOptions.getCompileCacheMaxSize());
+        }
+        Duration expireAfterAccess = initOptions.getCompileCacheExpireAfterAccess();
+        if (expireAfterAccess != null && !expireAfterAccess.isZero() && !expireAfterAccess.isNegative()) {
+            builder.expireAfterAccess(expireAfterAccess);
+        }
+        return builder.build();
     }
     
     public CustomFunction getFunction(String functionName) {
@@ -563,14 +577,7 @@ public class Express4Runner {
      * @return QLambdaDefinition and TracePointTrees
      */
     public QCompileCache parseToDefinitionWithCache(String script) {
-        try {
-            return getParseFuture(script).get();
-        }
-        catch (Exception e) {
-            Throwable compileException = e.getCause();
-            throw compileException instanceof QLSyntaxException ? (QLSyntaxException)compileException
-                : new RuntimeException(compileException);
-        }
+        return compileCache.get(script, this::parseDefinition);
     }
     
     public Value loadField(Object object, String fieldName) {
@@ -646,23 +653,20 @@ public class Express4Runner {
      * which may temporarily impact performance until the cache is rebuilt.
      */
     public void clearCompileCache() {
-        compileCache.clear();
+        compileCache.invalidateAll();
+        compileCache.cleanUp();
     }
-    
-    private Future<QCompileCache> getParseFuture(String script) {
-        Future<QCompileCache> parseFuture = compileCache.get(script);
-        if (parseFuture != null) {
-            return parseFuture;
-        }
-        FutureTask<QCompileCache> parseTask = new FutureTask<>(() -> parseDefinition(script));
-        Future<QCompileCache> preTask = compileCache.putIfAbsent(script, parseTask);
-        if (preTask == null) {
-            parseTask.run();
-            return parseTask;
-        }
-        return preTask;
+
+    /**
+     * Estimated number of entries currently held in the compile cache.
+     * Forces a cleanup pass first so size-based and time-based evictions are reflected in the result,
+     * which makes this convenient for monitoring and tests at the cost of some work per call.
+     */
+    public long compileCacheSize() {
+        compileCache.cleanUp();
+        return compileCache.estimatedSize();
     }
-    
+
     private QCompileCache parseDefinition(String script) {
         QLParser.ProgramContext program = parseToSyntaxTree(script);
         QvmInstructionVisitor qvmInstructionVisitor = new QvmInstructionVisitor(script, inheritDefaultImport(),

--- a/src/main/java/com/alibaba/qlexpress4/InitOptions.java
+++ b/src/main/java/com/alibaba/qlexpress4/InitOptions.java
@@ -4,6 +4,7 @@ import com.alibaba.qlexpress4.aparser.ImportManager;
 import com.alibaba.qlexpress4.aparser.InterpolationMode;
 import com.alibaba.qlexpress4.security.QLSecurityStrategy;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -82,11 +83,23 @@ public class InitOptions {
      * default is true
      */
     private final boolean strictNewLines;
-    
+
+    /**
+     * Maximum number of entries the compile cache can hold before eviction kicks in.
+     * Negative or zero means unbounded (backward compatible default).
+     */
+    private final long compileCacheMaxSize;
+
+    /**
+     * Expire compile cache entries after this duration since the last access.
+     * {@code null} means no expiration (default).
+     */
+    private final Duration compileCacheExpireAfterAccess;
+
     private InitOptions(ClassSupplier classSupplier, List<ImportManager.QLImport> defaultImport, boolean debug,
         Consumer<String> debugInfoConsumer, QLSecurityStrategy securityStrategy, boolean allowPrivateAccess,
         InterpolationMode interpolationMode, boolean traceExpression, String selectorStart, String selectorEnd,
-        boolean strictNewLines) {
+        boolean strictNewLines, long compileCacheMaxSize, Duration compileCacheExpireAfterAccess) {
         this.classSupplier = classSupplier;
         this.defaultImport = defaultImport;
         this.debug = debug;
@@ -98,6 +111,8 @@ public class InitOptions {
         this.selectorStart = selectorStart;
         this.selectorEnd = selectorEnd;
         this.strictNewLines = strictNewLines;
+        this.compileCacheMaxSize = compileCacheMaxSize;
+        this.compileCacheExpireAfterAccess = compileCacheExpireAfterAccess;
     }
     
     public static InitOptions.Builder builder() {
@@ -147,7 +162,15 @@ public class InitOptions {
     public boolean isStrictNewLines() {
         return strictNewLines;
     }
-    
+
+    public long getCompileCacheMaxSize() {
+        return compileCacheMaxSize;
+    }
+
+    public Duration getCompileCacheExpireAfterAccess() {
+        return compileCacheExpireAfterAccess;
+    }
+
     public static class Builder {
         private ClassSupplier classSupplier = DefaultClassSupplier.getInstance();
         
@@ -175,7 +198,11 @@ public class InitOptions {
         private String selectorEnd = "}";
         
         private boolean strictNewLines = true;
-        
+
+        private long compileCacheMaxSize = -1L;
+
+        private Duration compileCacheExpireAfterAccess = null;
+
         public Builder classSupplier(ClassSupplier classSupplier) {
             this.classSupplier = classSupplier;
             return this;
@@ -236,10 +263,29 @@ public class InitOptions {
             this.strictNewLines = strictNewLines;
             return this;
         }
-        
+
+        /**
+         * Limit the compile cache to {@code compileCacheMaxSize} entries; older entries are evicted
+         * by the underlying Caffeine policy. A non-positive value disables the bound (default).
+         */
+        public Builder compileCacheMaxSize(long compileCacheMaxSize) {
+            this.compileCacheMaxSize = compileCacheMaxSize;
+            return this;
+        }
+
+        /**
+         * Drop compile cache entries that have not been accessed for the given duration.
+         * {@code null} or a non-positive duration disables expiration (default).
+         */
+        public Builder compileCacheExpireAfterAccess(Duration compileCacheExpireAfterAccess) {
+            this.compileCacheExpireAfterAccess = compileCacheExpireAfterAccess;
+            return this;
+        }
+
         public InitOptions build() {
             return new InitOptions(classSupplier, defaultImport, debug, debugInfoConsumer, securityStrategy,
-                allowPrivateAccess, interpolationMode, traceExpression, selectorStart, selectorEnd, strictNewLines);
+                allowPrivateAccess, interpolationMode, traceExpression, selectorStart, selectorEnd, strictNewLines,
+                compileCacheMaxSize, compileCacheExpireAfterAccess);
         }
     }
 }

--- a/src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java
+++ b/src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java
@@ -3,6 +3,7 @@ package com.alibaba.qlexpress4;
 import com.alibaba.fastjson2.JSONObject;
 import com.alibaba.qlexpress4.annotation.QLFunction;
 import com.alibaba.qlexpress4.aparser.ImportManager;
+import com.alibaba.qlexpress4.aparser.QCompileCache;
 import com.alibaba.qlexpress4.aparser.InterpolationMode;
 import com.alibaba.qlexpress4.api.BatchAddFunctionResult;
 import com.alibaba.qlexpress4.exception.QLErrorCodes;
@@ -32,6 +33,7 @@ import org.junit.Test;
 import java.lang.reflect.Member;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -61,7 +63,125 @@ public class Express4RunnerTest {
         express4Runner.parseToDefinitionWithCache("a+b");
         // end::parseToCache[]
     }
-    
+
+    @Test
+    public void compileCacheHitReturnsSameInstance() {
+        Express4Runner runner = new Express4Runner(InitOptions.DEFAULT_OPTIONS);
+        QCompileCache first = runner.parseToDefinitionWithCache("1+1");
+        QCompileCache second = runner.parseToDefinitionWithCache("1+1");
+        assertSame(first, second);
+    }
+
+    @Test
+    public void compileCacheDefaultUnbounded() {
+        Express4Runner runner = new Express4Runner(InitOptions.DEFAULT_OPTIONS);
+        for (int i = 0; i < 50; i++) {
+            runner.parseToDefinitionWithCache("a + " + i);
+        }
+        assertEquals(50L, runner.compileCacheSize());
+    }
+
+    @Test
+    public void compileCacheBoundedBySize() {
+        // tag::compileCacheMaxSize[]
+        Express4Runner runner =
+            new Express4Runner(InitOptions.builder().compileCacheMaxSize(2L).build());
+        for (int i = 0; i < 100; i++) {
+            runner.parseToDefinitionWithCache("a + " + i);
+        }
+        assertTrue("cache size should be bounded around 2, got " + runner.compileCacheSize(),
+            runner.compileCacheSize() <= 2L);
+        // end::compileCacheMaxSize[]
+    }
+
+    @Test
+    public void clearCompileCacheClearsAllEntries() {
+        Express4Runner runner = new Express4Runner(InitOptions.DEFAULT_OPTIONS);
+        runner.parseToDefinitionWithCache("1+1");
+        runner.parseToDefinitionWithCache("2+2");
+        assertEquals(2L, runner.compileCacheSize());
+        runner.clearCompileCache();
+        assertEquals(0L, runner.compileCacheSize());
+    }
+
+    @Test
+    public void compileCacheExpiresAfterAccess()
+        throws InterruptedException {
+        // tag::compileCacheExpireAfterAccess[]
+        Express4Runner runner = new Express4Runner(
+            InitOptions.builder().compileCacheExpireAfterAccess(Duration.ofSeconds(1)).build());
+        runner.parseToDefinitionWithCache("1+1");
+        assertEquals(1L, runner.compileCacheSize());
+        Thread.sleep(1500L);
+        assertEquals(0L, runner.compileCacheSize());
+        // end::compileCacheExpireAfterAccess[]
+    }
+
+    @Test
+    public void compileCacheExpiresAfterAccessSubSecond()
+        throws InterruptedException {
+        Express4Runner runner = new Express4Runner(
+            InitOptions.builder().compileCacheExpireAfterAccess(Duration.ofMillis(200)).build());
+        runner.parseToDefinitionWithCache("1+1");
+        assertEquals(1L, runner.compileCacheSize());
+        Thread.sleep(500L);
+        assertEquals(0L, runner.compileCacheSize());
+    }
+
+    @Test(expected = QLSyntaxException.class)
+    public void compileCacheDoesNotStoreFailures() {
+        Express4Runner runner = new Express4Runner(InitOptions.DEFAULT_OPTIONS);
+        try {
+            runner.parseToDefinitionWithCache("@@@invalid syntax@@@");
+            fail("expected QLSyntaxException");
+        }
+        catch (QLSyntaxException expected) {
+            assertEquals(0L, runner.compileCacheSize());
+            throw expected;
+        }
+    }
+
+    @Test
+    public void compileCacheUsedByExecuteWithCacheOption() {
+        Express4Runner runner =
+            new Express4Runner(InitOptions.builder().compileCacheMaxSize(10L).build());
+        QLOptions cachedOptions = QLOptions.builder().cache(true).build();
+        runner.execute("1+1", Collections.emptyMap(), cachedOptions);
+        runner.execute("1+1", Collections.emptyMap(), cachedOptions);
+        runner.execute("2+2", Collections.emptyMap(), cachedOptions);
+        assertEquals(2L, runner.compileCacheSize());
+
+        // execute() without cache should not populate the cache
+        runner.execute("3+3", Collections.emptyMap(), QLOptions.DEFAULT_OPTIONS);
+        assertEquals(2L, runner.compileCacheSize());
+    }
+
+    @Test
+    public void compileCacheConcurrentParsingComputesOnce()
+        throws InterruptedException {
+        Express4Runner runner = new Express4Runner(InitOptions.DEFAULT_OPTIONS);
+        int threads = 16;
+        ExecutorService executor = Executors.newFixedThreadPool(threads);
+        try {
+            List<java.util.concurrent.Future<QCompileCache>> futures = new ArrayList<>();
+            for (int i = 0; i < threads; i++) {
+                futures.add(executor.submit(() -> runner.parseToDefinitionWithCache("a + b * c")));
+            }
+            QCompileCache first = futures.get(0).get();
+            for (java.util.concurrent.Future<QCompileCache> future : futures) {
+                assertSame(first, future.get());
+            }
+            assertEquals(1L, runner.compileCacheSize());
+        }
+        catch (java.util.concurrent.ExecutionException e) {
+            throw new AssertionError(e);
+        }
+        finally {
+            executor.shutdown();
+            executor.awaitTermination(5L, TimeUnit.SECONDS);
+        }
+    }
+
     @Test
     public void addFunctionsDefinedInScriptTest()
         throws InterruptedException {


### PR DESCRIPTION
Replace the unbounded ConcurrentHashMap-based compile cache in Express4Runner with a Caffeine cache, and expose two new InitOptions to configure it:

- compileCacheMaxSize: cap the number of cached compiled scripts; entries are evicted by Caffeine's Window TinyLFU policy when exceeded.
- compileCacheExpireAfterAccess: drop entries that have not been read for the given Duration.

Both options default to disabled, preserving the previous unbounded behavior. Add Express4Runner#compileCacheSize for monitoring, update clearCompileCache to use Caffeine's invalidateAll, and document the new options in both the Chinese and English READMEs with runnable test snippets.