### PR TITLE
fix: empty for/while loop body causes script to return null

### DIFF
--- a/src/main/java/com/alibaba/qlexpress4/runtime/QLambdaEmpty.java
+++ b/src/main/java/com/alibaba/qlexpress4/runtime/QLambdaEmpty.java
@@ -15,7 +15,7 @@ public class QLambdaEmpty implements QLambda {
     @Override
     public QResult call(Object... params)
         throws Throwable {
-        return new QResult(Value.NULL_VALUE, QResult.ResultType.RETURN);
+        return QResult.NEXT_INSTRUCTION;
     }
     
 }

--- a/src/test/java/com/alibaba/qlexpress4/test/issue/Issue427Test.java
+++ b/src/test/java/com/alibaba/qlexpress4/test/issue/Issue427Test.java
@@ -1,0 +1,76 @@
+package com.alibaba.qlexpress4.test.issue;
+
+import com.alibaba.qlexpress4.Express4Runner;
+import com.alibaba.qlexpress4.InitOptions;
+import com.alibaba.qlexpress4.QLOptions;
+import org.junit.Test;
+import java.util.HashMap;
+import static org.junit.Assert.*;
+
+/**
+ * Regression tests for issue #427:
+ * Empty for loop body causes subsequent expressions to return null.
+ * 
+ * Root cause: QLambdaEmpty.call() returned QResult(NULL_VALUE, RETURN)
+ * instead of QResult(NULL_VALUE, NEXT_INSTRUCTION), causing the for loop
+ * to propagate a RETURN signal that terminated the entire script.
+ */
+public class Issue427Test {
+
+    private final Express4Runner runner = new Express4Runner(InitOptions.DEFAULT_OPTIONS);
+
+    @Test
+    public void emptyForLoop_shouldNotAffectSubsequentExpression() {
+        // Core regression: empty for body + trailing expression
+        Object result = runner.execute("for(int i=0;i<5;i++){} 1;", new HashMap<>(), QLOptions.DEFAULT_OPTIONS).getResult();
+        assertEquals(1, result);
+    }
+
+    @Test
+    public void emptyForLoop_conditionNeverMet_shouldNotAffectSubsequentExpression() {
+        // Loop condition false from start
+        Object result = runner.execute("for(int i=0;i<0;i++){i++;} 1;", new HashMap<>(), QLOptions.DEFAULT_OPTIONS).getResult();
+        assertEquals(1, result);
+    }
+
+    @Test
+    public void emptyWhileLoop_shouldNotAffectSubsequentExpression() {
+        Object result = runner.execute("while(false){} 1;", new HashMap<>(), QLOptions.DEFAULT_OPTIONS).getResult();
+        assertEquals(1, result);
+    }
+
+    @Test
+    public void forLoopWithExplicitReturn_shouldReturnCorrectly() {
+        // Explicit return inside for loop should still work
+        Object result = runner.execute("for(int i=0;i<5;i++){return 42;} 1;", new HashMap<>(), QLOptions.DEFAULT_OPTIONS).getResult();
+        assertEquals(42, result);
+    }
+
+    @Test
+    public void emptyForEachLoop_shouldNotAffectSubsequentExpression() {
+        // Empty for-each with empty collection
+        Object result = runner.execute("a = []; for(int item : a){} 1;", new HashMap<>(), QLOptions.DEFAULT_OPTIONS).getResult();
+        assertEquals(1, result);
+    }
+
+    @Test
+    public void emptyForLoop_withSemicolonBody_shouldWork() {
+        // for loop with just semicolon as body
+        Object result = runner.execute("for(int i=0;i<5;i++){;} 1;", new HashMap<>(), QLOptions.DEFAULT_OPTIONS).getResult();
+        assertEquals(1, result);
+    }
+
+    @Test
+    public void nonEmptyForLoop_shouldStillWork() {
+        // Verify normal for loops still work correctly
+        Object result = runner.execute("a=0; for(int i=0;i<5;i++){a=a+i;} a;", new HashMap<>(), QLOptions.DEFAULT_OPTIONS).getResult();
+        assertEquals(10, result); // 0+1+2+3+4 = 10
+    }
+
+    @Test
+    public void emptyForLoop_multipleStatementsAfter() {
+        // Multiple statements after empty for loop
+        Object result = runner.execute("for(int i=0;i<3;i++){} a=10; b=20; a+b;", new HashMap<>(), QLOptions.DEFAULT_OPTIONS).getResult();
+        assertEquals(30, result);
+    }
+}


### PR DESCRIPTION
## Problem

Issue #427 reports that an empty `for` loop body causes the entire script to return `null`, skipping any subsequent expressions:

```javascript
for(int i=0;i<5;i++) {
}
1;
// Expected: 1, Actual: null  ← BUG
```

## Root Cause

`QLambdaEmpty.call()` returned `QResult(NULL_VALUE, RETURN)` instead of `QResult(NULL_VALUE, NEXT_INSTRUCTION)`.

When a for/while loop body is empty `{}`, the parser compiles it as `QLambdaEmpty`. During execution:

1. `ForInstruction.execute()` calls `bodyLambda.call()` → gets `QResult(NULL_VALUE, RETURN)`
2. The switch on `bodyResult.getResultType()` matches `case RETURN:` → returns immediately
3. This RETURN propagates up to `QLambdaInner.callInner()`, which treats it as a script-level `return`
4. All subsequent instructions (including `ConstInstruction(1)`) are **never executed**
5. Final result: `null`

This is inconsistent with `QLambdaInner.callInner()` which returns `NEXT_INSTRUCTION` for an empty instruction list — both represent the same "no-op" semantic but returned different `ResultType`s.

## Fix

**`QLambdaEmpty.java` (line 18):**

```java
// Before:
return new QResult(Value.NULL_VALUE, QResult.ResultType.RETURN);

// After:
return QResult.NEXT_INSTRUCTION;
```

This makes empty lambda bodies behave as no-ops, consistent with the instruction-based execution path.

## Tests Added

`Issue427Test.java` with 8 test cases:

| Test | Expression | Expected |
|------|-----------|----------|
| `emptyForLoop_shouldNotAffectSubsequentExpression` | `for(int i=0;i<5;i++){} 1;` | `1` |
| `emptyForLoop_conditionNeverMet` | `for(int i=0;i<0;i++){i++;} 1;` | `1` |
| `emptyWhileLoop` | `while(false){} 1;` | `1` |
| `forLoopWithExplicitReturn` | `for(int i=0;i<5;i++){return 42;} 1;` | `42` |
| `emptyForEachLoop` | `a=[]; for(int item:a){} 1;` | `1` |
| `emptyForLoop_withSemicolonBody` | `for(int i=0;i<5;i++){;} 1;` | `1` |
| `nonEmptyForLoop` | `a=0; for(int i=0;i<5;i++){a=a+i;} a;` | `10` |
| `emptyForLoop_multipleStatementsAfter` | `for(int i=0;i<3;i++){} a=10; b=20; a+b;` | `30` |

## Test Results

```
Issue427Test: 8/8 passed ✓
Full suite: 212/212 passed, 0 failures, 0 errors ✓
```

Fixes #427