### PR TITLE
fix: propagate BREAK/CONTINUE from try-catch blocks to enclosing loops

### DIFF
--- a/src/main/java/com/alibaba/qlexpress4/runtime/instruction/TryCatchInstruction.java
+++ b/src/main/java/com/alibaba/qlexpress4/runtime/instruction/TryCatchInstruction.java
@@ -45,7 +45,10 @@ public class TryCatchInstruction extends QLInstruction {
         if (finalBody != null) {
             callFinal(qContext, qlOptions);
         }
-        if (tryCatchResult.getResultType() == QResult.ResultType.RETURN) {
+        QResult.ResultType resultType = tryCatchResult.getResultType();
+        if (resultType == QResult.ResultType.RETURN
+            || resultType == QResult.ResultType.BREAK
+            || resultType == QResult.ResultType.CONTINUE) {
             return tryCatchResult;
         }
         return QResult.NEXT_INSTRUCTION;

--- a/src/test/java/com/alibaba/qlexpress4/test/issue/TryCatchBreakContinueTest.java
+++ b/src/test/java/com/alibaba/qlexpress4/test/issue/TryCatchBreakContinueTest.java
@@ -1,0 +1,172 @@
+package com.alibaba.qlexpress4.test.issue;
+
+import java.util.HashMap;
+
+import com.alibaba.qlexpress4.Express4Runner;
+import com.alibaba.qlexpress4.InitOptions;
+import com.alibaba.qlexpress4.QLOptions;
+import com.alibaba.qlexpress4.security.QLSecurityStrategy;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for break/continue inside try-catch blocks within loops.
+ *
+ * Bug: TryCatchInstruction.execute() only propagated RETURN result type,
+ * but not BREAK or CONTINUE. This caused break/continue inside try blocks
+ * to be silently ignored when enclosed in a loop.
+ */
+public class TryCatchBreakContinueTest {
+
+    private static final InitOptions INIT_OPTIONS = InitOptions.builder()
+        .securityStrategy(QLSecurityStrategy.open()).build();
+
+    @Test
+    public void breakInsideTryShouldExitLoop() {
+        Express4Runner runner = new Express4Runner(INIT_OPTIONS);
+        // break inside try block should terminate the for loop
+        String script = "result = 0;\n"
+            + "for(int i = 0; i < 10; i++) {\n"
+            + "  try {\n"
+            + "    if (i == 3) { break; }\n"
+            + "    result = result + 1;\n"
+            + "  } catch(Exception e) {}\n"
+            + "}\n"
+            + "result;";
+        Object result = runner.execute(script, new HashMap<>(), QLOptions.DEFAULT_OPTIONS).getResult();
+        // Loop should execute for i=0,1,2 then break at i=3
+        Assert.assertEquals(3, result);
+    }
+
+    @Test
+    public void continueInsideTryShouldSkipIteration() {
+        Express4Runner runner = new Express4Runner(INIT_OPTIONS);
+        // continue inside try block should skip the rest of the iteration
+        String script = "result = 0;\n"
+            + "for(int i = 0; i < 5; i++) {\n"
+            + "  try {\n"
+            + "    if (i == 2 || i == 4) { continue; }\n"
+            + "    result = result + i;\n"
+            + "  } catch(Exception e) {}\n"
+            + "}\n"
+            + "result;";
+        Object result = runner.execute(script, new HashMap<>(), QLOptions.DEFAULT_OPTIONS).getResult();
+        // Should sum 0+1+3 = 4 (skipping i=2 and i=4)
+        Assert.assertEquals(4, result);
+    }
+
+    @Test
+    public void breakInsideTryWithFinallyShouldExitLoop() {
+        Express4Runner runner = new Express4Runner(INIT_OPTIONS);
+        // break inside try block with finally should still exit the loop
+        String script = "result = 0;\n"
+            + "for(int i = 0; i < 10; i++) {\n"
+            + "  try {\n"
+            + "    if (i == 2) { break; }\n"
+            + "    result = result + 1;\n"
+            + "  } catch(Exception e) {\n"
+            + "  } finally {\n"
+            + "  }\n"
+            + "}\n"
+            + "result;";
+        Object result = runner.execute(script, new HashMap<>(), QLOptions.DEFAULT_OPTIONS).getResult();
+        // Loop should execute for i=0,1 then break at i=2
+        Assert.assertEquals(2, result);
+    }
+
+    @Test
+    public void continueInsideTryWithFinallyShouldSkipIteration() {
+        Express4Runner runner = new Express4Runner(INIT_OPTIONS);
+        // continue inside try with finally should skip iteration
+        String script = "result = 0;\n"
+            + "for(int i = 0; i < 5; i++) {\n"
+            + "  try {\n"
+            + "    if (i == 3) { continue; }\n"
+            + "    result = result + i;\n"
+            + "  } catch(Exception e) {\n"
+            + "  } finally {\n"
+            + "  }\n"
+            + "}\n"
+            + "result;";
+        Object result = runner.execute(script, new HashMap<>(), QLOptions.DEFAULT_OPTIONS).getResult();
+        // Should sum 0+1+2+4 = 7 (skipping i=3)
+        Assert.assertEquals(7, result);
+    }
+
+    @Test
+    public void breakInsideCatchShouldExitLoop() {
+        Express4Runner runner = new Express4Runner(INIT_OPTIONS);
+        // break inside catch block should also exit the loop
+        String script = "result = 0;\n"
+            + "for(int i = 0; i < 10; i++) {\n"
+            + "  try {\n"
+            + "    if (i == 3) { throw new RuntimeException(\"stop\"); }\n"
+            + "    result = result + 1;\n"
+            + "  } catch(Exception e) {\n"
+            + "    break;\n"
+            + "  }\n"
+            + "}\n"
+            + "result;";
+        Object result = runner.execute(script, new HashMap<>(), QLOptions.DEFAULT_OPTIONS).getResult();
+        // Loop should execute for i=0,1,2 then throw at i=3, catch breaks
+        Assert.assertEquals(3, result);
+    }
+
+    @Test
+    public void continueInsideCatchShouldSkipIteration() {
+        Express4Runner runner = new Express4Runner(INIT_OPTIONS);
+        // continue inside catch block should skip to next iteration
+        String script = "result = 0;\n"
+            + "for(int i = 0; i < 5; i++) {\n"
+            + "  try {\n"
+            + "    if (i == 2) { throw new RuntimeException(\"skip\"); }\n"
+            + "    result = result + i;\n"
+            + "  } catch(Exception e) {\n"
+            + "    continue;\n"
+            + "  }\n"
+            + "}\n"
+            + "result;";
+        Object result = runner.execute(script, new HashMap<>(), QLOptions.DEFAULT_OPTIONS).getResult();
+        // i=0: result+=0=0, i=1: result+=1=1, i=2: throw->catch->continue (skip),
+        // i=3: result+=3=4, i=4: result+=4=8
+        Assert.assertEquals(8, result);
+    }
+
+    @Test
+    public void breakInsideWhileTryShouldExitLoop() {
+        Express4Runner runner = new Express4Runner(INIT_OPTIONS);
+        // break inside try in a while loop
+        String script = "i = 0; result = 0;\n"
+            + "while(i < 10) {\n"
+            + "  try {\n"
+            + "    if (i == 5) { break; }\n"
+            + "    result = result + 1;\n"
+            + "  } catch(Exception e) {}\n"
+            + "  i = i + 1;\n"
+            + "}\n"
+            + "result;";
+        Object result = runner.execute(script, new HashMap<>(), QLOptions.DEFAULT_OPTIONS).getResult();
+        // Loop should execute for i=0,1,2,3,4 then break at i=5
+        Assert.assertEquals(5, result);
+    }
+
+    @Test
+    public void breakInsideNestedTryShouldExitLoop() {
+        Express4Runner runner = new Express4Runner(INIT_OPTIONS);
+        // break inside nested try blocks
+        String script = "result = 0;\n"
+            + "for(int i = 0; i < 10; i++) {\n"
+            + "  try {\n"
+            + "    try {\n"
+            + "      if (i == 4) { break; }\n"
+            + "      result = result + 1;\n"
+            + "    } catch(Exception e) {}\n"
+            + "  } catch(Exception e) {}\n"
+            + "}\n"
+            + "result;";
+        Object result = runner.execute(script, new HashMap<>(), QLOptions.DEFAULT_OPTIONS).getResult();
+        // Should execute for i=0,1,2,3 then break at i=4
+        Assert.assertEquals(4, result);
+    }
+}


### PR DESCRIPTION
## Problem

When `break` or `continue` is executed inside a try-catch block within a loop, the control flow signal is silently discarded by `TryCatchInstruction`, causing the loop to continue instead of breaking/continuing.

```javascript
for (int i = 0; i < 10; i++) {
    try {
        if (i == 3) { break; }  // This break was ignored!
        result = result + 1;
    } catch(Exception e) {}
}
// Expected: result == 3, Actual: result == 10
```

## Root Cause

`TryCatchInstruction.execute()` only propagated `ResultType.RETURN`, discarding `BREAK` and `CONTINUE`:

```java
if (tryCatchResult.getResultType() == QResult.ResultType.RETURN) {
    return tryCatchResult;
}
return QResult.NEXT_INSTRUCTION;  // BREAK/CONTINUE lost here!
```

This is the same class of bug as #427 — `QResult.ResultType` not being properly propagated through control flow instructions.

## Fix

Added `BREAK` and `CONTINUE` to the propagation check in `TryCatchInstruction.execute()`:

```java
QResult.ResultType resultType = tryCatchResult.getResultType();
if (resultType == QResult.ResultType.RETURN
    || resultType == QResult.ResultType.BREAK
    || resultType == QResult.ResultType.CONTINUE) {
    return tryCatchResult;
}
```

## Tests

Added `TryCatchBreakContinueTest.java` with 8 test cases covering:

| Test | Scenario |
|------|----------|
| `breakInsideTryShouldExitLoop` | `break` in try block exits for loop |
| `continueInsideTryShouldSkipIteration` | `continue` in try skips iteration |
| `breakInsideTryWithFinallyShouldExitLoop` | `break` + finally block |
| `continueInsideTryWithFinallyShouldSkipIteration` | `continue` + finally block |
| `breakInsideCatchShouldExitLoop` | `break` in catch block |
| `continueInsideCatchShouldSkipIteration` | `continue` in catch block |
| `breakInsideWhileTryShouldExitLoop` | `break` in while loop try |
| `breakInsideNestedTryShouldExitLoop` | `break` in nested try blocks |

Related: same `QResult` propagation pattern as #427 (empty for loop fix)