### PR TITLE
fix tracepoint display for variable selection

### DIFF
--- a/src/main/java/com/alibaba/qlexpress4/aparser/QLParser.java
+++ b/src/main/java/com/alibaba/qlexpress4/aparser/QLParser.java
@@ -191,8 +191,9 @@ public class QLParser {
     public static final int OPID = QLexer.OPID;
     
     public static final int SELECTOR_START = QLexer.SELECTOR_START;
+    
     public static final int SELECTOR_END = QLexer.SELECTOR_END;
-
+    
     public static final int ID = QLexer.ID;
     
     public static final int DOUBLE_QUOTE = QLexer.DOUBLE_QUOTE;
@@ -2969,7 +2970,7 @@ public class QLParser {
         private TerminalNode selectorStart;
         
         private TerminalNode selectorVariable;
-
+        
         private TerminalNode selectorEnd;
         
         public TerminalNode SELECTOR_START() {

--- a/src/main/java/com/alibaba/qlexpress4/aparser/QLParser.java
+++ b/src/main/java/com/alibaba/qlexpress4/aparser/QLParser.java
@@ -191,7 +191,8 @@ public class QLParser {
     public static final int OPID = QLexer.OPID;
     
     public static final int SELECTOR_START = QLexer.SELECTOR_START;
-    
+    public static final int SELECTOR_END = QLexer.SELECTOR_END;
+
     public static final int ID = QLexer.ID;
     
     public static final int DOUBLE_QUOTE = QLexer.DOUBLE_QUOTE;
@@ -815,6 +816,8 @@ public class QLParser {
             ctx.selectorStart = consumeNode(ctx);
             ctx.selectorVariable = new TerminalNode(expect(SelectorVariable_VANME, "selector variable"));
             ctx.addChild(ctx.selectorVariable);
+            ctx.selectorEnd = new TerminalNode(expect(SELECTOR_END, "selector end"));
+            ctx.addChild(ctx.selectorEnd);
             return ctx;
         }
         if (isVarIdToken(lt().getType())) {
@@ -2966,6 +2969,8 @@ public class QLParser {
         private TerminalNode selectorStart;
         
         private TerminalNode selectorVariable;
+
+        private TerminalNode selectorEnd;
         
         public TerminalNode SELECTOR_START() {
             return selectorStart;

--- a/src/main/java/com/alibaba/qlexpress4/aparser/QLexer.java
+++ b/src/main/java/com/alibaba/qlexpress4/aparser/QLexer.java
@@ -206,7 +206,8 @@ public class QLexer {
     public static final int SelectorVariable_VANME = 96;
     
     public static final int CATCH_ALL = 97;
-    
+    public static final int SELECTOR_END = 98;
+
     private static final Map<String, Integer> KEYWORDS = new HashMap<>();
     
     static {
@@ -406,6 +407,10 @@ public class QLexer {
                 for (int i = 0; i < selectorEnd.length(); i++) {
                     advance();
                 }
+                int endStart = p;
+                int endLine = line;
+                int endCol = col;
+                add(SELECTOR_END, selectorEnd, endStart, endStart + selectorEnd.length() - 1, endLine, endCol);
                 return;
             }
             if (ch() == '\n' || ch() == '\r') {

--- a/src/main/java/com/alibaba/qlexpress4/aparser/QLexer.java
+++ b/src/main/java/com/alibaba/qlexpress4/aparser/QLexer.java
@@ -206,8 +206,9 @@ public class QLexer {
     public static final int SelectorVariable_VANME = 96;
     
     public static final int CATCH_ALL = 97;
+    
     public static final int SELECTOR_END = 98;
-
+    
     private static final Map<String, Integer> KEYWORDS = new HashMap<>();
     
     static {

--- a/src/main/java/com/alibaba/qlexpress4/aparser/TraceExpressionVisitor.java
+++ b/src/main/java/com/alibaba/qlexpress4/aparser/TraceExpressionVisitor.java
@@ -451,7 +451,7 @@ public class TraceExpressionVisitor extends QLParserBaseVisitor<TracePointTree> 
     
     @Override
     public TracePointTree visitContextSelectExpr(QLParser.ContextSelectExprContext ctx) {
-        return newPoint(TraceType.PRIMARY, Collections.emptyList(), ctx.getStart());
+        return newPoint(TraceType.PRIMARY, Collections.emptyList(), ctx.getText(), ctx.getStart());
     }
     
     // ==================== Private Helper ====================

--- a/src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java
+++ b/src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java
@@ -281,6 +281,12 @@ public class Express4RunnerTest {
                 + "              | VALUE 2 2\n" + "      | STATEMENT break null\n" + "  | BLOCK result \n"
                 + "      | OPERATOR = \n" + "          | VARIABLE result \n" + "          | VALUE 0 \n",
             resultSwitch.getExpressionTraces().get(0).toPrettyString(0));
+        QLResult resultSelect = express4Runner.execute("${a} + 1 == 2", Collections.singletonMap("a", 1),
+                QLOptions.builder().traceExpression(true).build());
+        Assert.assertEquals(
+                "OPERATOR == true\n" + "  | OPERATOR + 2\n" + "      | PRIMARY ${a} 1\n" + "      | VALUE 1 1\n" + "  | VALUE 2 2\n",
+                resultSelect.getExpressionTraces().get(0).toPrettyString(0)
+        );
     }
     
     @Test

--- a/src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java
+++ b/src/test/java/com/alibaba/qlexpress4/Express4RunnerTest.java
@@ -281,12 +281,13 @@ public class Express4RunnerTest {
                 + "              | VALUE 2 2\n" + "      | STATEMENT break null\n" + "  | BLOCK result \n"
                 + "      | OPERATOR = \n" + "          | VARIABLE result \n" + "          | VALUE 0 \n",
             resultSwitch.getExpressionTraces().get(0).toPrettyString(0));
-        QLResult resultSelect = express4Runner.execute("${a} + 1 == 2", Collections.singletonMap("a", 1),
-                QLOptions.builder().traceExpression(true).build());
+        QLResult resultSelect = express4Runner.execute("${a} + 1 == 2",
+            Collections.singletonMap("a", 1),
+            QLOptions.builder().traceExpression(true).build());
         Assert.assertEquals(
-                "OPERATOR == true\n" + "  | OPERATOR + 2\n" + "      | PRIMARY ${a} 1\n" + "      | VALUE 1 1\n" + "  | VALUE 2 2\n",
-                resultSelect.getExpressionTraces().get(0).toPrettyString(0)
-        );
+            "OPERATOR == true\n" + "  | OPERATOR + 2\n" + "      | PRIMARY ${a} 1\n" + "      | VALUE 1 1\n"
+                + "  | VALUE 2 2\n",
+            resultSelect.getExpressionTraces().get(0).toPrettyString(0));
     }
     
     @Test


### PR DESCRIPTION
表达式中使用${变量名}引用变量时，表达式追踪展示的是${，
例如
表达式 `${x} == 1`，打印追踪信息为
```
| OPERATOR == false
          | PRIMARY ${ null
          | VALUE 1 1
```

修改后展示为${变量名}

```
OPERATOR == false
  | PRIMARY ${x} null
  | VALUE 1 1
```