### PR TITLE
Add Windows and macOS to CI build matrix and fix cross-platform issues

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -4,7 +4,10 @@ on: [push]
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 11

--- a/src/main/java/com/alibaba/qlexpress4/aparser/QLexer.java
+++ b/src/main/java/com/alibaba/qlexpress4/aparser/QLexer.java
@@ -431,7 +431,7 @@ public class QLexer {
                 continue;
             }
             if (c == '\'') {
-                add(QuoteStringLiteral, script.substring(start, p), start, p - 1, startLine, startCol);
+                add(QuoteStringLiteral, normalizeNewlines(script.substring(start, p)), start, p - 1, startLine, startCol);
                 return;
             }
         }
@@ -454,7 +454,7 @@ public class QLexer {
                 if (c == '"') {
                     if (p > textStart) {
                         add(StaticStringCharacters,
-                            script.substring(textStart, p),
+                            normalizeNewlines(script.substring(textStart, p)),
                             textStart,
                             p - 1,
                             textLine,
@@ -484,7 +484,7 @@ public class QLexer {
                 }
             }
             if (p > textStart) {
-                add(DyStrText, script.substring(textStart, p), textStart, p - 1, textLine, textCol);
+                add(DyStrText, normalizeNewlines(script.substring(textStart, p)), textStart, p - 1, textLine, textCol);
             }
             if (eof()) {
                 scannerError(currentToken(script.substring(quoteStart)), "unterminated string literal");
@@ -947,5 +947,9 @@ public class QLexer {
             token.getText(),
             QLErrorCodes.SYNTAX_ERROR.name(),
             reason);
+    }
+
+    private static String normalizeNewlines(String text) {
+        return text.replace("\r\n", "\n").replace("\r", "\n");
     }
 }


### PR DESCRIPTION
## What is the purpose of this PR

We were unable to access the account from which we originally opened PR #445. Rather than waiting to recover that account, we've opened this new PR with the same changes, incorporating the feedback and addressing the review comments from the previous PR. We apologize for the inconvenience.

The CI workflow currently runs only on `ubuntu-latest`. This PR extends the build matrix to include `windows-latest` and `macos-latest`, and fixes a platform-specific issue that was uncovered when running the test suite on Windows.

## Expected Result

The project builds and tests successfully on Ubuntu, Windows, and macOS with consistent behavior across platforms.

## Windows-specific issue

### Multi-line string literals fail on Windows

**Expected:**  
`assert("hello\nworld" == "hello\nworld")` passes on all platforms.

**Actual:**  
The assertion fails on Windows.

**Why:**  
Windows uses `\r\n` (CRLF) line endings, while Unix-based systems use `\n` (LF). Scripts read from disk therefore contain different newline sequences depending on the platform, causing multi-line string literals to produce different values.

**Fix:**  
Normalize all line endings to `\n` before lexing and parsing.

## Changes

- Add `windows-latest` and `macos-latest` to the CI matrix
- Normalize line endings (`CRLF`/`CR` → `LF`) in QLexer

## Description of Fix

Scripts are now normalized to use Unix-style line endings (`\n`) before tokenization and parsing. This removes platform-dependent differences in multi-line string literals and ensures scripts behave consistently on Windows, macOS, and Linux.

## Updates
Addressed the review from @DQinYuan by implementing the suggested approach: modifying `QLexer` instead of replacing the script content in `src/main/java/com/alibaba/qlexpress4/aparser/SyntaxTreeFactory.java`.